### PR TITLE
Fix modules iterator test

### DIFF
--- a/test/modulesIter.test.mo
+++ b/test/modulesIter.test.mo
@@ -81,7 +81,7 @@ func pairCompare(a: (Text, Principal), b: (Text, Principal)): {#less; #equal; #g
 var i = 0;
 for (t in testsData.vals()) {
     test("test" # debug_show(i), func() {
-        let iter = Common.ModulesIterator(t.arg);
+        let iter = Common.modulesIterator(t.arg);
         let res0 = Iter.sort<(Text, Principal)>(iter, pairCompare);
         let res = Iter.toArray<(Text, Principal)>(res0);
         let expected0 = Iter.toArray<(Text, Principal)>(t.result.vals());


### PR DESCRIPTION
## Summary
- fix incorrect function name in `modulesIter.test.mo`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b22f966648321a8758ef94f3659d9