### PR TITLE
Fix amendPath query building

### DIFF
--- a/src/package_manager_frontend/src/MyNavigate.tsx
+++ b/src/package_manager_frontend/src/MyNavigate.tsx
@@ -11,20 +11,20 @@ export function MyLink(props: {to: string, className?: string, children: React.R
     return <Link to={amendPath(props.to)} className={props.className} children={props.children}/>
 }
 
-function amendPath(path: string): string {
+export function amendPath(path: string): string {
     const params = new URLSearchParams(window.location.search);
     const canisterId = params.get('canisterId');
     const backend = params.get('_pm_pkg0.backend');
 
-    let s = path;
-    if (canisterId !== null || backend !== null) {
-        s += "?";
-    }
+    const pieces: string[] = [];
     if (canisterId !== null) {
-        s += "canisterId=" + canisterId;
+        pieces.push(`canisterId=${canisterId}`);
     }
     if (backend !== null) {
-        s += "_pm_pkg0.backend=" + backend;
+        pieces.push(`_pm_pkg0.backend=${backend}`);
     }
-    return s;
+    if (pieces.length > 0) {
+        return path + '?' + pieces.join('&');
+    }
+    return path;
 }

--- a/test/MyNavigate.test.ts
+++ b/test/MyNavigate.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { amendPath } from '../src/package_manager_frontend/src/MyNavigate';
+
+describe('amendPath', () => {
+  const originalWindow = global.window;
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  it('handles only canisterId', () => {
+    global.window = { location: { search: '?canisterId=abc' } } as any;
+    expect(amendPath('/foo')).to.equal('/foo?canisterId=abc');
+  });
+
+  it('handles only backend', () => {
+    global.window = { location: { search: '?_pm_pkg0.backend=def' } } as any;
+    expect(amendPath('/foo')).to.equal('/foo?_pm_pkg0.backend=def');
+  });
+
+  it('handles both params', () => {
+    global.window = { location: { search: '?canisterId=abc&_pm_pkg0.backend=def' } } as any;
+    expect(amendPath('/foo')).to.equal('/foo?canisterId=abc&_pm_pkg0.backend=def');
+  });
+});


### PR DESCRIPTION
## Summary
- export `amendPath` and fix query string generation
- add unit tests for the URL amendment logic

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b263d994c8321ac0820153f551e49