### PR TITLE
Update equalPrincipalSet assertion

### DIFF
--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -80,17 +80,18 @@ function getCanisterNameFromPrincipal(principal: Principal): string {
 }
 
 Assertion.addMethod('equalPrincipalSet', function (expected) {
-    const actual = this._obj;
-    const actualStrings = Array.from(actual).map(p => getCanisterNameFromPrincipal(p as Principal)).sort();
-    const expectedStrings = Array.from(expected).map(p => getCanisterNameFromPrincipal(p as Principal)).sort();
-    
+    const actual = this._obj as Set<any>;
+    const actualStrings = Array.from(actual).map(p => getCanisterNameFromPrincipal(p as Principal));
+    const expectedStrings = Array.from(expected).map(p => getCanisterNameFromPrincipal(p as Principal));
+
+    const isEqual = areEqualSets(new Set(actualStrings), new Set(expectedStrings));
+
     this.assert(
-        expect(actualStrings).to.deep.equal(expectedStrings),
-        // expect(actualStrings).to.have.same.members(expectedStrings),
+        isEqual,
         "expected #{act} to equal #{exp}",
         "expected #{act} to not equal #{exp}",
-        expectedStrings,
-        actualStrings
+        expectedStrings.sort(),
+        actualStrings.sort()
     );
 });
   


### PR DESCRIPTION
## Summary
- update `equalPrincipalSet` to compute equality without using `expect`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b27a59e3c8321a50c0d8e8c8e95d5