### PR TITLE
Add investment feature to wallet frontend

### DIFF
--- a/src/wallet_frontend/src/App.tsx
+++ b/src/wallet_frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Tabs from 'react-bootstrap/Tabs';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import TokensTable from './TokensTable';
 import Settings from './Settings';
+import Invest from './Invest';
 import { AuthProvider, useAuth } from '../../lib/use-auth-client';
 import { AuthButton }  from '../../lib/AuthButton';
 import { ErrorBoundary, ErrorHandler } from "../../lib/ErrorBoundary";
@@ -69,7 +70,7 @@ function App2() {
                     <Settings/>
                 </Tab>
                 <Tab eventKey="invest" title="Invest">
-                    <p>Investment features coming soon...</p>
+                    <Invest/>
                 </Tab>
             </Tabs>
 

--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { useAuth } from '../../lib/use-auth-client';
+import { createActor as createPSTActor } from '../../declarations/pst';
+import { Principal } from '@dfinity/principal';
+
+const DECIMALS = 8;
+const INITIAL_SUPPLY = 33334 * 4 * Math.pow(10, DECIMALS);
+const LIMIT_ICP = 33333.32;
+
+function investedFromMinted(mintedTokensICP: number): number {
+  const b = LIMIT_ICP;
+  return b - Math.sqrt(b * b - 1.5 * b * mintedTokensICP);
+}
+
+function mintedForInvestment(prevInvest: number, invest: number): number {
+  const b = LIMIT_ICP;
+  const newTotal = prevInvest + invest;
+  return (4 / 3) * (newTotal - prevInvest) -
+    (2 / (3 * b)) * (newTotal * newTotal - prevInvest * prevInvest);
+}
+
+export default function Invest() {
+  const { agent, ok } = useAuth();
+  const [amountICP, setAmountICP] = useState('');
+  const [expected, setExpected] = useState<number | null>(null);
+  const [totalInvested, setTotalInvested] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!agent) return;
+    const pst = createPSTActor(Principal.fromText(process.env.CANISTER_ID_PST!), { agent });
+    pst.icrc1_total_supply().then((s: bigint) => {
+      const minted = Number(s.toString()) - INITIAL_SUPPLY;
+      const mintedICP = minted / Math.pow(10, DECIMALS);
+      setTotalInvested(investedFromMinted(mintedICP));
+    }).catch(console.error);
+  }, [agent]);
+
+  useEffect(() => {
+    if (totalInvested === null) { setExpected(null); return; }
+    const val = parseFloat(amountICP);
+    if (isNaN(val) || val <= 0) { setExpected(null); return; }
+    const res = mintedForInvestment(totalInvested, val);
+    setExpected(res);
+  }, [amountICP, totalInvested]);
+
+  const handleBuy = async () => {
+    if (!agent || !ok) return;
+    setLoading(true);
+    try {
+      const pst = createPSTActor(Principal.fromText(process.env.CANISTER_ID_PST!), { agent });
+      await pst.buyWithICP();
+      setAmountICP('');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Form>
+      <Form.Group className="mb-3">
+        <Form.Label>ICP to invest</Form.Label>
+        <Form.Control
+          type="number"
+          min="0"
+          step="any"
+          value={amountICP}
+          onChange={e => setAmountICP(e.target.value)}
+        />
+      </Form.Group>
+      <div className="mb-3">
+        Estimated ICPACK: {expected !== null ? expected.toFixed(4) : 'N/A'}
+      </div>
+      <Button onClick={handleBuy} disabled={!ok || loading || !amountICP}>
+        {loading ? 'Buying...' : 'Buy'}
+      </Button>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `Invest` component in wallet frontend
- wire up Investment tab in wallet `App` to use new component

## Testing
- `npm test` *(fails: Cannot find module 'node-fetch')*

------
https://chatgpt.com/codex/tasks/task_e_684b624094148321abe66542cffd9238