### PR TITLE
Implement Debt tracking helper

### DIFF
--- a/src/bootstrapper_backend/bootstrapper.mo
+++ b/src/bootstrapper_backend/bootstrapper.mo
@@ -27,6 +27,7 @@ import TrieMap "mo:base/TrieMap";
 import Order "mo:base/Order";
 import Map "mo:base/OrderedMap";
 import env "mo:env";
+import Debt "../lib/Debt";
 import Account "../lib/Account";
 import AccountID "mo:account-identifier";
 import ICPLedger "canister:nns-ledger";
@@ -384,7 +385,7 @@ actor class Bootstrapper() = this {
 
         // Deduct revenue:
         let revenue = Int.abs(Float.toInt(Float.fromInt(balance) * env.revenueShare));
-        indebt(revenueRecipient, revenue);
+        Debt.indebt(revenueRecipient, revenue);
 
         let res = await CyclesLedger.withdraw({
             amount = balance - revenue - Common.cycles_transfer_fee;
@@ -411,7 +412,7 @@ actor class Bootstrapper() = this {
 
         // Deduct revenue:
         let revenue = Int.abs(Float.toInt(Float.fromInt(icpBalance) * env.revenueShare));
-        indebt(revenueRecipient, revenue);
+        Debt.indebt(revenueRecipient, revenue);
 
         let res = await ICPLedger.icrc1_transfer({
             to = {

--- a/src/lib/Debt.mo
+++ b/src/lib/Debt.mo
@@ -1,0 +1,22 @@
+import BTree "mo:base/BTree";
+import Principal "mo:base/Principal";
+
+module {
+  public type Debts = BTree.BTree<Principal, Nat>;
+  stable var debts : Debts = BTree.init<Principal, Nat>(null);
+
+  public func indebt(p : Principal, amount : Nat) {
+    let prev = switch (BTree.get(debts, Principal.compare, p)) {
+      case (?v) v;
+      case null 0;
+    };
+    debts := BTree.put(debts, Principal.compare, p, prev + amount);
+  };
+
+  public func debtOf(p : Principal) : Nat {
+    switch (BTree.get(debts, Principal.compare, p)) {
+      case (?v) v;
+      case null 0;
+    }
+  };
+}

--- a/src/package_manager_backend/battery.mo
+++ b/src/package_manager_backend/battery.mo
@@ -20,6 +20,7 @@ import ICPLedger "canister:nns-ledger";
 import CyclesLedger "canister:cycles_ledger";
 import CMC "canister:nns-cycles-minting";
 import env "mo:env";
+import Debt "../lib/Debt";
 
 shared({caller = initialOwner}) actor class Battery({
     packageManager: Principal; // may be the bootstrapper instead.
@@ -207,7 +208,7 @@ shared({caller = initialOwner}) actor class Battery({
         if (newCycles != 0) {
             // let fee = Float.toInt(Float.fromInt(newCycles) * 0.05); // 5%
             let fee = newCycles / 20; // 5%
-            indebt(revenueRecipient, fee);
+            Debt.indebt(revenueRecipient, fee);
             battery.activatedCycles += newCycles - fee;
         };
 
@@ -299,7 +300,7 @@ shared({caller = initialOwner}) actor class Battery({
 
         // Deduct revenue:
         let revenue = Int.abs(Float.toInt(Float.fromInt(balance) * env.revenueShare));
-        indebt(revenueRecipient, revenue);
+        Debt.indebt(revenueRecipient, revenue);
 
         let res = await CyclesLedger.withdraw({
             amount = balance - revenue - Common.cycles_transfer_fee;
@@ -319,7 +320,7 @@ shared({caller = initialOwner}) actor class Battery({
 
         // Deduct revenue:
         let revenue = Int.abs(Float.toInt(Float.fromInt(icpBalance) * env.revenueShare));
-        indebt(revenueRecipient, revenue);
+        Debt.indebt(revenueRecipient, revenue);
 
         let res = await ICPLedger.icrc1_transfer({
             to = {

--- a/src/wallet_backend/wallet.mo
+++ b/src/wallet_backend/wallet.mo
@@ -9,6 +9,7 @@ import ICRC1 "mo:icrc1-types";
 import ICPLedger "canister:nns-ledger";
 import Int "mo:base/Int";
 import BTree "mo:base/BTree";
+import Debt "../lib/Debt";
 
 persistent actor class Wallet({
     user: Principal; // Pass the anonymous principal `2vxsx-fae` to be controlled by nobody.
@@ -213,7 +214,7 @@ persistent actor class Wallet({
     switch (_buyerAffiliate) {
       case (?_buyerAffiliate) {
         let _buyerAffiliateAmount = Int.abs(Fractions.mul(_amount, buyerAffiliateShare));
-        indebt(_buyerAffiliate, _buyerAffiliateAmount);
+        Debt.indebt(_buyerAffiliate, _buyerAffiliateAmount);
         if (_shareHoldersAmount < _buyerAffiliateAmount) {
           Debug.trap("negative amount to pay");
         };
@@ -224,7 +225,7 @@ persistent actor class Wallet({
     switch (_sellerAffiliate) {
       case (?_sellerAffiliate) {
         let _sellerAffiliateAmount = Int.abs(Fractions.mul(_amount, sellerAffiliateShare));
-        indebt(_sellerAffiliate, _sellerAffiliateAmount);
+        Debt.indebt(_sellerAffiliate, _sellerAffiliateAmount);
         if (_shareHoldersAmount < _sellerAffiliateAmount) {
           Debug.trap("negative amount to pay");
         };
@@ -244,7 +245,7 @@ persistent actor class Wallet({
       return 0;
     };
     lastDividendsPerToken := BTree.put(lastDividendsPerToken, Principal.compare, caller, dividendPerToken);
-    indebt(caller, amount);
+    Debt.indebt(caller, amount);
     amount;
   };
 


### PR DESCRIPTION
## Summary
- introduce `Debt` module for recording debts
- import `Debt` module in battery, bootstrapper and wallet backends
- replace calls to undefined `indebt` with `Debt.indebt`

## Testing
- `npm test` *(fails: Cannot find module 'node-fetch')*

------
https://chatgpt.com/codex/tasks/task_e_684b67ff0f7c8321add4335dc87b3a24