### PR TITLE
Fix type errors in PST token calculations

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -148,9 +148,9 @@ shared ({ caller = initialOwner }) actor class PST() : async ICRC1.FullInterface
         };
         let mintedF = newMintedF - prevMintedF;
         let mintedInt = Int.abs(Float.toInt(mintedF));
-        let minted : Nat = Nat64.toNat(Int.abs(mintedInt));
+        let minted : Nat = mintedInt;
         totalInvested += invest;
-        totalMinted += Nat64.toNat(Int.abs(Float.toInt(newMintedF - prevMintedF)));
+        totalMinted += Int.abs(Float.toInt(newMintedF - prevMintedF));
 
         let mintResult = await this.mint({
             to = { owner = user; subaccount = null };


### PR DESCRIPTION
## Summary
- fix minted token calculation conversions to avoid Nat64 mismatch

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684bb42bacc083218001e2672386a052