### PR TITLE
Add Invest button for ICPACK token

### DIFF
--- a/src/wallet_frontend/src/App.tsx
+++ b/src/wallet_frontend/src/App.tsx
@@ -65,7 +65,7 @@ function App2() {
                         <Button disabled={!ok} onClick={handleAddToken}>Add token</Button>
                         {!ok && <>{" "}Login to add a token.</>}
                     </p>
-                    {ok && <TokensTable key={tokensKey}/>}
+                    {ok && <TokensTable key={tokensKey} onInvest={() => setActiveTab('invest')}/>}
                 </Tab>
                 <Tab eventKey="settings" title="Settings">
                     <Settings/>


### PR DESCRIPTION
## Summary
- add onInvest prop in wallet front-end tokens table
- show Invest button for ICPACK token and hook to App tabs
- identify the PST token by canister ID instead of name

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND)*
- `npm run build` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c19b1613c8321b6ae42f26ecec2f8