### PR TITLE
Add disclaimers to Invest tab

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -86,6 +86,16 @@ export default function Invest() {
       <Button onClick={handleBuy} disabled={!ok || loading || !amountICP}>
         {loading ? 'Buying...' : 'Buy'}
       </Button>
+      <p className="mt-3">
+        We don't warrant any return of investment. Invest on your own risk.
+      </p>
+      <p>
+        The investment may be more profitable if you buy the token early,
+        because of a discount for early investors. At later stage the price of
+        ICPACK token swiftly goes up, making the investment unprofitable. Invest
+        early.
+      </p>
+      <p>TODO@P2 There will be added a widget to withdraw your dividends.</p>
     </Form>
   );
 }


### PR DESCRIPTION
## Summary
- add disclaimers about investment risks on Invest tab

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684c2a0f6e048321b03d3b4dfef06756