### PR TITLE
Add percent scale to ICPACK chart

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -62,6 +62,18 @@ const chartOptions = {
   scales: {
     x: { type: 'linear', title: { display: true, text: 'ICP' } },
     y: { title: { display: true, text: 'ICPACK' } },
+    yPercent: {
+      type: 'linear',
+      position: 'right',
+      title: { display: true, text: '% of max ICPACK' },
+      grid: { drawOnChartArea: false },
+      ticks: {
+        callback: (value: string | number) =>
+          `${(Number(value) / TOTAL_SUPPLY * 100).toFixed(1)}%`,
+      },
+      min: 0,
+      max: LIMIT_TOKENS,
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- show ICPACK percentages on a second Y axis

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684c399b72dc8321b884ef349f8f8a8c