### PR TITLE
Update Invest page with PST pledge

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -223,6 +223,13 @@ export default function Invest() {
         We don't warrant any return of investment. Invest on your own risk.
       </p>
       <p>
+        Hereby our company All World Files Corp warrants that we won't mint more
+        than 20% of the profit sharing token (PST) and that all our profits on
+        blockchain will be routed through this PST proportionally to holdings.
+        This way we preserve validity of your investment, not to be diluted by
+        minting too much PST.
+      </p>
+      <p>
         The investment may be more profitable if you buy the token early,
         because of a discount for early investors. At later stage the price of
         ICPACK token swiftly goes up, making the investment unprofitable. Invest


### PR DESCRIPTION
## Summary
- add text about limiting PST minting and routing profits through PST on the Invest page

## Testing
- `make deploy-test && npm test` *(fails: `dfx: command not found`)*
- `npm test` *(fails: `MODULE_NOT_FOUND`)*

------
https://chatgpt.com/codex/tasks/task_e_684c431c8f348321964b85c443082678