### PR TITLE
Display owed dividends

### DIFF
--- a/src/wallet_backend/wallet.mo
+++ b/src/wallet_backend/wallet.mo
@@ -214,6 +214,10 @@ persistent actor class Wallet({
     balance * perTokenDelta / DIVIDEND_SCALE;
   };
 
+  public query({caller}) func dividendsOwing() : async Nat {
+    await _dividendsOwing(caller);
+  };
+
   func recalculateShareholdersDebt(_amount: Nat, _buyerAffiliate: ?Principal, _sellerAffiliate: ?Principal) : async () {
     // Affiliates are delivered by frontend.
     // address payable _buyerAffiliate = affiliates[msg.sender];


### PR DESCRIPTION
## Summary
- expose a `dividendsOwing` query in wallet backend
- load owed dividends in Invest page
- show owed dividends beside Withdraw Dividends button

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684c492685148321a12181b89bcde02d