### PR TITLE
Remove superfluous principal arg from Debt

### DIFF
--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -96,13 +96,13 @@ persistent actor class BootstrapperData(initialOwner: Principal) {
 
     public type Token = { #icp; #cycles };
 
-    stable var debtsICP: Debt.Debts = Debt.map().empty<Nat>();
-    stable var debtsCycles: Debt.Debts = Debt.map().empty<Nat>();
+    stable var debtsICP: Debt.Debts = 0;
+    stable var debtsCycles: Debt.Debts = 0;
 
     public shared func indebt({caller: Principal; amount: Nat; token: Token}): () {
         switch token {
-            case (#icp) { Debt.indebt({var debtsICP; p = caller; amount}); };
-            case (#cycles) { Debt.indebt({var debtsCycles; p = caller; amount}); };
+            case (#icp) { Debt.indebt({var debtsICP; amount}); };
+            case (#cycles) { Debt.indebt({var debtsCycles; amount}); };
         };
     };
 }

--- a/src/lib/Debt.mo
+++ b/src/lib/Debt.mo
@@ -1,24 +1,15 @@
-import Map "mo:base/OrderedMap";
-import Principal "mo:base/Principal";
-
+// Debt tracking utilities. All debts belong to PST holders collectively.
 module {
-  public func map(): Map.Operations<Principal> = Map.Make<Principal>(Principal.compare);
+  /// Mutable debt value.
+  public type Debts = Nat;
 
-  public type Debts = Map.Map<Principal, Nat>;
-
-  // FIXME@P1: What is `p`?
-  public func indebt(args: {var debts: Debts; p : Principal; amount : Nat}) {
-    let prev = switch (map().get(args.debts, args.p)) {
-      case (?v) v;
-      case null 0;
-    };
-    args.debts := map().put(args.debts, args.p, prev + args.amount);
+  /// Increase `debts` by `amount`.
+  public func indebt(args : { var debts : Debts; amount : Nat }) {
+    args.debts := args.debts + args.amount;
   };
 
-  public func debtOf(args: {var debts: Debts; p : Principal}) : Nat {
-    switch (map().get(args.debts, args.p)) {
-      case (?v) v;
-      case null 0;
-    }
+  /// Return the current debt amount.
+  public func debtOf(args : { var debts : Debts }) : Nat {
+    args.debts
   };
 }


### PR DESCRIPTION
## Summary
- simplify Debt library by removing the principal-based accounting
- adjust BootstrapperData to use new Debt interface

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684c86bccfc48321b16a64f7817308cc