### PR TITLE
Implement per-token dividend tracking

### DIFF
--- a/src/wallet_backend/wallet.mo
+++ b/src/wallet_backend/wallet.mo
@@ -196,42 +196,63 @@ persistent actor class Wallet({
   /// Dividends and Withdrawals ///
 
   /// Dividends are accounted per token to avoid newly minted PST receiving
-  /// a share of previously declared dividends.  `dividendPerToken` stores the
+  /// a share of previously declared dividends.  `dividendPerToken*` store the
   /// cumulative dividend amount scaled by `DIVIDEND_SCALE`.
   let DIVIDEND_SCALE : Nat = 1_000_000_000;
-  stable var dividendPerToken = 0;
-  // TODO: Set a heavy transfer fee of the PST to ensure that `lastDividendsPerToken` doesn't take much memory.
-  stable var lastDividendsPerToken = principalMap.empty<Nat>();
+  stable var dividendPerTokenICP = 0;
+  stable var dividendPerTokenCycles = 0;
+  // TODO: Set a heavy transfer fee of the PST to ensure that `lastDividendsPerToken*` doesn't take much memory.
+  stable var lastDividendsPerTokenICP = principalMap.empty<Nat>();
+  stable var lastDividendsPerTokenCycles = principalMap.empty<Nat>();
 
-  func _dividendsOwing(_account: Principal): async Nat {
-    let last = switch (principalMap.get(lastDividendsPerToken, _account)) {
-      case (?value) { value };
-      case (null) { 0 };
+  func _dividendsOwing(_account: Principal, token: BootstrapperData.Token): async Nat {
+    let last = switch token {
+      case (#icp) { switch (principalMap.get(lastDividendsPerTokenICP, _account)) { case (?value) { value }; case (null) { 0 }; } };
+      case (#cycles) { switch (principalMap.get(lastDividendsPerTokenCycles, _account)) { case (?value) { value }; case (null) { 0 }; } };
     };
-    let perTokenDelta = Int.abs((dividendPerToken: Int) - last);
+    let perTokenDelta = switch token {
+      case (#icp) { Int.abs((dividendPerTokenICP: Int) - last) };
+      case (#cycles) { Int.abs((dividendPerTokenCycles: Int) - last) };
+    };
     let balance = await PST.icrc1_balance_of({owner = _account; subaccount = null});
     balance * perTokenDelta / DIVIDEND_SCALE;
   };
 
   public query({caller}) func dividendsOwing() : async Nat {
-    await _dividendsOwing(caller);
+    await _dividendsOwing(caller, #icp);
   };
 
-  // FIXME@P1: separate per ICP and per Cycles
-  func recalculateShareholdersDebt(amount: Nat) : async () {
+  public query({caller}) func dividendsOwingCycles() : async Nat {
+    await _dividendsOwing(caller, #cycles);
+  };
+
+  func recalculateShareholdersDebt(amount: Nat, token: BootstrapperData.Token) : async () {
     let totalSupply = await PST.icrc1_total_supply();
-    dividendPerToken += amount * DIVIDEND_SCALE / totalSupply;
+    switch token {
+      case (#icp) { dividendPerTokenICP += amount * DIVIDEND_SCALE / totalSupply };
+      case (#cycles) { dividendPerTokenCycles += amount * DIVIDEND_SCALE / totalSupply };
+    };
   };
 
-  /// Withdraw owed dividends and record the snapshot of `dividendPerToken`
+  /// Withdraw owed dividends and record the snapshot of `dividendPerToken*`
   /// for the caller so that newly minted tokens do not get past dividends.
   public shared({caller}) func withdrawDividends() : async Nat {
-    let amount = await _dividendsOwing(caller);
+    let amount = await _dividendsOwing(caller, #icp);
     if (amount == 0) {
       return 0;
     };
-    lastDividendsPerToken := principalMap.put(lastDividendsPerToken, caller, dividendPerToken);
+    lastDividendsPerTokenICP := principalMap.put(lastDividendsPerTokenICP, caller, dividendPerTokenICP);
     ignore BootstrapperData.indebt({caller; amount; token = #icp});
+    amount;
+  };
+
+  public shared({caller}) func withdrawCyclesDividends() : async Nat {
+    let amount = await _dividendsOwing(caller, #cycles);
+    if (amount == 0) {
+      return 0;
+    };
+    lastDividendsPerTokenCycles := principalMap.put(lastDividendsPerTokenCycles, caller, dividendPerTokenCycles);
+    ignore BootstrapperData.indebt({caller; amount; token = #cycles});
     amount;
   };
 };


### PR DESCRIPTION
## Summary
- track dividend accounting separately for ICP and Cycles
- expose query functions to check ICP and Cycle dividends separately
- withdraw dividends for both ICP and Cycles

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684cb6d5dc188321adb9c7ab4acd153c