### PR TITLE
Fix dividends owing call

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -149,11 +149,17 @@ export default function Invest() {
   };
 
   const loadOwedDividends = async () => {
-    if (!glob.walletBackend || !principal) return;
+    if (!agent || !ok) return;
     try {
-      const owed = await (glob.walletBackend as any).dividendsOwing();
+      const { createActor } = await import('../../declarations/bootstrapper_data');
+      const dataActor = createActor(
+        Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
+        { agent }
+      );
+      const owed = await (dataActor as any).dividendsOwing({ icp: null });
+      const owedC = await (dataActor as any).dividendsOwing({ cycles: null });
       setOwedDividends(Number(owed.toString()) / Math.pow(10, DECIMALS));
-      setOwedCycles(0);
+      setOwedCycles(Number(owedC.toString()));
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
## Summary
- use `bootstrapper_data` actor to fetch owed dividends in wallet frontend

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684cc169316c832192560734edc90918