### PR TITLE
Increase graph line thickness

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -43,6 +43,7 @@ const baseDataset = {
   label: 'ICPACK vs ICP',
   data: GRAPH_DATA,
   borderColor: 'rgb(75, 192, 192)',
+  borderWidth: 5,
   backgroundColor: 'rgba(75, 192, 192, 0.4)',
   showLine: true,
   fill: false,


### PR DESCRIPTION
## Summary
- tweak wallet chart dataset settings to increase graph line thickness

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684e68cbb4188321ba1404121f34352f