### PR TITLE
Join comment blocks in pst.mo

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -366,11 +366,30 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
     /// Buy ICPACK with ICP transferred to the caller's subaccount.
     ///
     /// The amount of tokens minted is determined by integrating a price curve
-    /// over the caller's investment.  Initially, each ICP buys 4/3 ICPACK.  At
+    /// over the caller's investment. Initially, each ICP buys 4/3 ICPACK. At
     /// 16,666.66 ICP invested in total the rate drops to half that, and after
-    /// about twice that amount of ICPACK has been bought the cost grows without bound. The
-    /// integral ensures that investing 16,666.66 ICP mints exactly the same
-    /// amount of ICPACK while early investors receive proportionally more.
+    /// about twice that amount of ICPACK has been bought the cost grows without
+    /// bound. The integral ensures that investing 16,666.66 ICP mints exactly
+    /// the same amount of ICPACK while early investors receive proportionally
+    /// more.
+    ///
+    /// The number of PST tokens minted for an ICP investment is given by
+    /// integrating a price curve which gradually increases the cost of a token
+    /// as more ICP is invested. The shape of the curve is chosen so that:
+    ///   * investing 16,666.66 ICP in total results in 16,666.66 newly minted
+    ///     ICPACK tokens (one token per ICP on average);
+    ///   * at the very beginning the buyer receives twice as many ICPACK per
+    ///     ICP as at the 16,666.66 ICP mark; and
+    ///   * once about twice that amount of ICPACK (33,333.32 ICPACK) has been
+    ///     bought, the price tends to infinity and no new ICPACK can be
+    ///     purchased.
+    ///
+    /// These conditions are satisfied when the instantaneous number of ICPACK
+    /// tokens obtainable for one ICP depends linearly on the total number of
+    /// ICPACK already minted, `g(m) = 4/3 * (1 - m/L)` where `L` is twice
+    /// 16,666.66 ICPACK expressed in e8s. Integrating this expression yields a
+    /// curve that approaches `L` tokens as the required investment tends to
+    /// infinity.
     public shared({caller = user}) func buyWithICP() : async ICRC1.TransferResult {
         // FIXME@P1: Ensure that token exchange is reliable.
         let subaccount = Common.principalToSubaccount(user);
@@ -393,23 +412,6 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
             case (#Err e) { return #Err e };
             case (#Ok _) {};
         };
-
-        // The number of PST tokens minted for an ICP investment is given by
-        // integrating a price curve which gradually increases the cost of a token
-        // as more ICP is invested.  The shape of the curve is chosen so that:
-        //   * investing 16,666.66 ICP in total results in 16,666.66 newly minted
-        //     ICPACK tokens (one token per ICP on average);
-        //   * at the very beginning the buyer receives twice as many ICPACK per
-        //     ICP as at the 16,666.66 ICP mark; and
-        //   * once about twice that amount of ICPACK (33,333.32 ICPACK) has been
-        //     bought, the price tends to infinity and no new ICPACK can be purchased.
-        //
-        // These conditions are satisfied when the instantaneous number of
-        // ICPACK tokens obtainable for one ICP depends linearly on the total
-        // number of ICPACK already minted, `g(m) = 4/3 * (1 - m/L)` where `L`
-        // is twice 16,666.66 ICPACK expressed in e8s.  Integrating this
-        // expression yields a curve that approaches `L` tokens as the required
-        // investment tends to infinity.
 
         let limitTokens = 3_333_332_000_000; // ~33,333.32 ICPACK in e8s
 


### PR DESCRIPTION
## Summary
- combine two separate comment sections in `pst.mo` into a single introductory block
- remove redundant comment inside the function

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_684f8a6a32cc8321b57781ef843fb761