### PR TITLE
Unify dividend withdrawal API

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -212,7 +212,7 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent }
       );
-      await (dataActor as any).withdrawICPDividends();
+      await (dataActor as any).withdrawDividends({ icp: null });
     } catch (err) {
       console.error(err);
     } finally {
@@ -231,7 +231,7 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent }
       );
-      await (dataActor as any).withdrawCyclesDividends();
+      await (dataActor as any).withdrawDividends({ cycles: null });
     } catch (err) {
       console.error(err);
     } finally {


### PR DESCRIPTION
## Summary
- merge ICP and Cycles dividend withdrawal functions into a single `withdrawDividends`
- introduce `tokenPrincipal` helper
- update frontend to use the unified API

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6851941951d08321b49c34e6cf3b5466