### PR TITLE
Simplify dividends transfer logic

### DIFF
--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -248,17 +248,6 @@ persistent actor class BootstrapperData(initialOwner: Principal) = this {
                 lockDividendsAccount[i] := principalMap.delete(lockDividendsAccount[i], user);
                 return 0;
             };
-
-            let existing = await icrc1.icrc1_balance_of(accountWithDividends(user));
-
-            current := dividendsLock(i, user);
-
-            if (existing >= Common.icp_transfer_fee) {
-                dividendsCheckpointPerToken[i] := principalMap.put(dividendsCheckpointPerToken[i], user, current.dividendsCheckpoint);
-                lockDividendsAccount[i] := principalMap.delete(lockDividendsAccount[i], user);
-                return existing;
-            };
-
             if (not current.transferring) {
                 let ts = if (current.createdAtTime == 0) { Nat64.fromNat(Int.abs(Time.now())) } else { current.createdAtTime };
                 current := {current with transferring = true; createdAtTime = ts};


### PR DESCRIPTION
## Summary
- simplify `putDividendsOnTmpAccount` by removing existing-balance check

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68559e49780c8321875b770e3e496a2f