### PR TITLE
Fix total tracking during ICP buys

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -460,6 +460,7 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
 
     public type MintLock = {
         minted: Nat;
+        invest: Nat;
         createdAtTime: Nat64;
     };
 
@@ -493,17 +494,15 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
             let mintedF = newMintedF - prevMintedF;
             let mintedInt = Int.abs(Float.toInt(mintedF));
             let minted : Nat = Int.abs(mintedInt);
-            totalInvested += invest;
-            totalMinted += Int.abs(Float.toInt(newMintedF - prevMintedF));
             let ts = Nat64.fromNat(Int.abs(Time.now()));
-            let nl : MintLock = { minted; createdAtTime = ts };
+            let nl : MintLock = { minted; invest; createdAtTime = ts };
             tokenToDeliver := principalMap.put(tokenToDeliver, user, nl);
             nl;
           };
         };
         // await icrc1_transfer({ // FIXME@P1: Uncomment.
         //   memo = null;
-        //   amount = invest;
+        //   amount = lock.invest;
         //   fee = null;
         //   from_subaccount = ?investmentAccount.subaccount;
         //   to = recipientAccount;
@@ -523,6 +522,8 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
           case(#err(#trappable(err))) D.trap(err);
           case(#err(#awaited(err))) D.trap(err);
         };
+        totalInvested += lock.invest;
+        totalMinted += lock.minted;
         tokenToDeliver := principalMap.delete(tokenToDeliver, user);
         (); // FIXME@P1
     };


### PR DESCRIPTION
## Summary
- store invested amount in `MintLock`
- record totals only after mint completes

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6855aeb92f6c8321a2cfd4163cf53a17