### PR TITLE
Fix mint_tokens caller in finishBuyWithICP

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -550,7 +550,7 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
         let investmentAccount = accountWithInvestment(user);
         if (not lock.mintedDone) {
             // We don't use `await mint()` also because it's async and breaks reliability.
-            let _ = switch (await* icrc1().mint_tokens(user, {
+            let _ = switch (await* icrc1().mint_tokens(owner, {
               to = {owner = wallet; subaccount = ?(Common.principalToSubaccount(user))};
               amount = lock.minted;
               memo = null;


### PR DESCRIPTION
## Summary
- pass the minting account owner when minting tokens during ICP purchases

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6855c392cc048321a0c2b43a57027ec6