### PR TITLE
Fix finishBuyWithICP clearing lock

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -645,6 +645,10 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
         totalInvested += lock.invest;
         totalMinted += lock.minted;
         tokenToDeliver := principalMap.delete(tokenToDeliver, user);
+        // Remove any investment lock since the invested ICP was drained
+        // from the user's dedicated account. This prevents retries from
+        // attempting `icrc1_transfer` again with stale timestamps.
+        lockInvestAccount := principalMap.delete(lockInvestAccount, user);
         release();
         (); // FIXME@P1
     };


### PR DESCRIPTION
## Summary
- clean up stale investment lock after ICP transfer in `finishBuyWithICP`

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*
- `make deploy-test` *(fails: `dfx` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ca4441bc8321a2c134418190990f