### PR TITLE
Simplify ICRC calls

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -223,13 +223,17 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
       icrc1().supported_standards();
   };
 
-  public shared ({ caller }) func icrc1_transfer(args : ICRC1.TransferArgs) : async ICRC1.TransferResult {
-      switch(await* icrc1().transfer_tokens(caller, args, false, null)){
+  private func awaitOrTrap<T>(op : async* { #trappable : T; #awaited : T; #err : { #trappable : Text; #awaited : Text } }) : async T {
+      switch(await* op){
         case(#trappable(val)) val;
         case(#awaited(val)) val;
-        case(#err(#trappable(err))) D.trap(err);
-        case(#err(#awaited(err))) D.trap(err);
+        case(#err(#trappable(err))) Debug.trap(err);
+        case(#err(#awaited(err))) Debug.trap(err);
       };
+  };
+
+  public shared ({ caller }) func icrc1_transfer(args : ICRC1.TransferArgs) : async ICRC1.TransferResult {
+      await awaitOrTrap(icrc1().transfer_tokens(caller, args, false, null));
   };
 
   public shared ({ caller }) func mint(args : ICRC1.Mint) : async ICRC1.TransferResult {
@@ -243,21 +247,11 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
         }
       };
 
-      switch( await* icrc1().mint_tokens(caller, mintArgs)){
-        case(#trappable(val)) val;
-        case(#awaited(val)) val;
-        case(#err(#trappable(err))) D.trap(err);
-        case(#err(#awaited(err))) D.trap(err);
-      };
+      await awaitOrTrap(icrc1().mint_tokens(caller, mintArgs));
   };
 
   public shared ({ caller }) func burn(args : ICRC1.BurnArgs) : async ICRC1.TransferResult {
-      switch( await*  icrc1().burn_tokens(caller, args, false)){
-        case(#trappable(val)) val;
-        case(#awaited(val)) val;
-        case(#err(#trappable(err))) D.trap(err);
-        case(#err(#awaited(err))) D.trap(err);
-      };
+      await awaitOrTrap(icrc1().burn_tokens(caller, args, false));
   };
 
    public query ({ caller }) func icrc2_allowance(args: ICRC2.AllowanceArgs) : async ICRC2.Allowance {
@@ -265,21 +259,11 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
     };
 
   public shared ({ caller }) func icrc2_approve(args : ICRC2.ApproveArgs) : async ICRC2.ApproveResponse {
-      switch(await*  icrc2().approve_transfers(caller, args, false, null)){
-        case(#trappable(val)) val;
-        case(#awaited(val)) val;
-        case(#err(#trappable(err))) D.trap(err);
-        case(#err(#awaited(err))) D.trap(err);
-      };
+      await awaitOrTrap(icrc2().approve_transfers(caller, args, false, null));
   };
 
   public shared ({ caller }) func icrc2_transfer_from(args : ICRC2.TransferFromArgs) : async ICRC2.TransferFromResponse {
-      switch(await* icrc2().transfer_tokens_from(caller, args, null)){
-        case(#trappable(val)) val;
-        case(#awaited(val)) val;
-        case(#err(#trappable(err))) D.trap(err);
-        case(#err(#awaited(err))) D.trap(err);
-      };
+      await awaitOrTrap(icrc2().transfer_tokens_from(caller, args, null));
   };
 
   public shared ({ caller }) func admin_update_owner(new_owner : Principal) : async Bool {


### PR DESCRIPTION
## Summary
- simplify calls to ICRC ledgers by adding `awaitOrTrap`
- refactor several methods to use the helper and reduce duplication

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6855d36709008321b496891ef93eab81