### PR TITLE
Fix compile errors in PST canister

### DIFF
--- a/src/wallet_backend/pst.mo
+++ b/src/wallet_backend/pst.mo
@@ -223,17 +223,19 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
       icrc1().supported_standards();
   };
 
-  private func awaitOrTrap<T>(op : async* { #trappable : T; #awaited : T; #err : { #trappable : Text; #awaited : Text } }) : async T {
-      switch(await* op){
-        case(#trappable(val)) val;
-        case(#awaited(val)) val;
-        case(#err(#trappable(err))) Debug.trap(err);
-        case(#err(#awaited(err))) Debug.trap(err);
-      };
+  private func awaitOrTrap<T>(op : async* { #trappable : T; #awaited : T; #err : { #trappable : Text; #awaited : Text } }) : async* T {
+      async* {
+        switch(await* op){
+          case(#trappable(val)) val;
+          case(#awaited(val)) val;
+          case(#err(#trappable(err))) Debug.trap(err);
+          case(#err(#awaited(err))) Debug.trap(err);
+        };
+      }
   };
 
   public shared ({ caller }) func icrc1_transfer(args : ICRC1.TransferArgs) : async ICRC1.TransferResult {
-      await awaitOrTrap(icrc1().transfer_tokens(caller, args, false, null));
+      await* awaitOrTrap(icrc1().transfer_tokens(caller, args, false, null));
   };
 
   public shared ({ caller }) func mint(args : ICRC1.Mint) : async ICRC1.TransferResult {
@@ -247,11 +249,11 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
         }
       };
 
-      await awaitOrTrap(icrc1().mint_tokens(caller, mintArgs));
+      await* awaitOrTrap(icrc1().mint_tokens(caller, mintArgs));
   };
 
   public shared ({ caller }) func burn(args : ICRC1.BurnArgs) : async ICRC1.TransferResult {
-      await awaitOrTrap(icrc1().burn_tokens(caller, args, false));
+      await* awaitOrTrap(icrc1().burn_tokens(caller, args, false));
   };
 
    public query ({ caller }) func icrc2_allowance(args: ICRC2.AllowanceArgs) : async ICRC2.Allowance {
@@ -259,11 +261,11 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
     };
 
   public shared ({ caller }) func icrc2_approve(args : ICRC2.ApproveArgs) : async ICRC2.ApproveResponse {
-      await awaitOrTrap(icrc2().approve_transfers(caller, args, false, null));
+      await* awaitOrTrap(icrc2().approve_transfers(caller, args, false, null));
   };
 
   public shared ({ caller }) func icrc2_transfer_from(args : ICRC2.TransferFromArgs) : async ICRC2.TransferFromResponse {
-      await awaitOrTrap(icrc2().transfer_tokens_from(caller, args, null));
+      await* awaitOrTrap(icrc2().transfer_tokens_from(caller, args, null));
   };
 
   public shared ({ caller }) func admin_update_owner(new_owner : Principal) : async Bool {
@@ -502,7 +504,7 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
 
     private func cleanupTokenToDeliver(now : Nat64) : Nat {
         var removed : Nat = 0;
-        var i = tokenToDeliver.entries();
+        var i = principalMap.entries(tokenToDeliver);
         loop {
             switch(i.next()) {
                 case(null) break;
@@ -519,7 +521,7 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
 
     private func cleanupFinishBuyLocks(now : Nat64) : Nat {
         var removed : Nat = 0;
-        var i = finishBuyLock.entries();
+        var i = principalMap.entries(finishBuyLock);
         loop {
             switch(i.next()) {
                 case(null) break;
@@ -557,7 +559,7 @@ shared ({ caller = _owner }) actor class Token  (args : ?{
         switch(res) { case (#Ok _) true; case (#Err(#Duplicate _)) true; case (#Err _) false };
     };
 
-    private func ledgerTransferICP(args : ICPLedger.TransferArgs) : async Bool {
+    private func ledgerTransferICP(args : ICPLedger.TransferArg) : async Bool {
         switch(await ICPLedger.icrc1_transfer(args)) {
             case (#Ok _) true;
             case (#Err(#Duplicate _)) true;


### PR DESCRIPTION
## Summary
- update `awaitOrTrap` to return `async*` and adjust callsites
- fix map usage with `entries` helper
- use correct type `TransferArg` for ICP ledger transfers

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6855dac6d9ec8321bde874fe63ad1eb1