### PR TITLE
Fix buy error handling

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -192,7 +192,9 @@ export default function Invest() {
       const pst = createActor(Principal.fromText(process.env.CANISTER_ID_PST!), { agent });
       const investE8s = BigInt(Math.round(parseFloat(amountICP) * 1e8));
       const res = await pst.buyWithICP(glob.walletBackendPrincipal, investE8s);
-      if (res && 'Err' in res) {
+      if (!res) {
+        setError('Failed to buy tokens');
+      } else if ('Err' in res) {
         const err = (res as any).Err;
         const msg = err.GenericError?.message ?? JSON.stringify(err);
         setError(msg);


### PR DESCRIPTION
## Summary
- improve wallet Invest tab error reporting when buyWithICP returns nothing

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6856ed95835c8321abfe2aa7eca43fb9