### PR TITLE
Fix wallet balance display

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -16,6 +16,7 @@ import { useAuth } from '../../lib/use-auth-client';
 import { Principal } from '@dfinity/principal';
 import { ErrorContext } from '../../lib/ErrorContext';
 import { GlobalContext } from './state';
+import { principalToSubaccount } from './accountUtils';
 
 ChartJS.register(
   CategoryScale,
@@ -142,12 +143,12 @@ export default function Invest() {
   }, [agent]);
 
   const loadBalance = async () => {
-    if (!glob.walletBackend || !principal || !defaultAgent) return;
+    if (!glob.walletBackendPrincipal || !principal || !defaultAgent) return;
     const { createActor } = await import('../../declarations/pst');
     const pst = createActor(Principal.fromText(process.env.CANISTER_ID_PST!), { agent: defaultAgent });
     try {
-      const account = await glob.walletBackend.getUserWallet(principal);
-      const bal = await pst.icrc1_balance_of(account);
+      const account = { owner: glob.walletBackendPrincipal, subaccount: principalToSubaccount(principal) };
+      const bal = await pst.icrc1_balance_of(account as any);
       setIcpackBalance(Number(bal.toString()) / Math.pow(10, DECIMALS));
     } catch (e) {
       console.error(e);
@@ -212,7 +213,7 @@ export default function Invest() {
   };
 
   const handleWithdrawICP = async () => {
-    if (!agent || !ok || !glob.walletBackend || !principal) return;
+    if (!agent || !ok || !glob.walletBackend || !glob.walletBackendPrincipal || !principal) return;
     setWithdrawing(true);
     try {
       const { createActor } = await import('../../declarations/bootstrapper_data');
@@ -220,8 +221,8 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent }
       );
-      const to = await glob.walletBackend.getUserWallet(principal);
-      await (dataActor as any).withdrawDividends({ icp: null }, to);
+      const to = { owner: glob.walletBackendPrincipal, subaccount: principalToSubaccount(principal) };
+      await (dataActor as any).withdrawDividends({ icp: null }, to as any);
     } catch (err) {
       console.error(err);
     } finally {
@@ -232,7 +233,7 @@ export default function Invest() {
   };
 
   const handleWithdrawCycles = async () => {
-    if (!agent || !ok || !glob.walletBackend || !principal) return;
+    if (!agent || !ok || !glob.walletBackend || !glob.walletBackendPrincipal || !principal) return;
     setWithdrawing(true);
     try {
       const { createActor } = await import('../../declarations/bootstrapper_data');
@@ -240,8 +241,8 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent }
       );
-      const to = await glob.walletBackend.getUserWallet(principal);
-      await (dataActor as any).withdrawDividends({ cycles: null }, to);
+      const to = { owner: glob.walletBackendPrincipal, subaccount: principalToSubaccount(principal) };
+      await (dataActor as any).withdrawDividends({ cycles: null }, to as any);
     } catch (err) {
       console.error(err);
     } finally {
@@ -270,7 +271,7 @@ export default function Invest() {
   };
 
   const handleFinishWithdrawICP = async () => {
-    if (!agent || !ok || !glob.walletBackend || !principal) return;
+    if (!agent || !ok || !glob.walletBackend || !glob.walletBackendPrincipal || !principal) return;
     setFinishingWithdraw(true);
     try {
       const { createActor } = await import('../../declarations/bootstrapper_data');
@@ -278,8 +279,8 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent }
       );
-      const to = await glob.walletBackend.getUserWallet(principal);
-      await (dataActor as any).finishWithdrawDividends({ icp: null }, to);
+      const to = { owner: glob.walletBackendPrincipal, subaccount: principalToSubaccount(principal) };
+      await (dataActor as any).finishWithdrawDividends({ icp: null }, to as any);
       loadBalance();
       loadOwedDividends();
     } catch (err) {
@@ -290,7 +291,7 @@ export default function Invest() {
   };
 
   const handleFinishWithdrawCycles = async () => {
-    if (!agent || !ok || !glob.walletBackend || !principal) return;
+    if (!agent || !ok || !glob.walletBackend || !glob.walletBackendPrincipal || !principal) return;
     setFinishingWithdraw(true);
     try {
       const { createActor } = await import('../../declarations/bootstrapper_data');
@@ -298,8 +299,8 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent }
       );
-      const to = await glob.walletBackend.getUserWallet(principal);
-      await (dataActor as any).finishWithdrawDividends({ cycles: null }, to);
+      const to = { owner: glob.walletBackendPrincipal, subaccount: principalToSubaccount(principal) };
+      await (dataActor as any).finishWithdrawDividends({ cycles: null }, to as any);
       loadBalance();
       loadOwedDividends();
     } catch (err) {

--- a/src/wallet_frontend/src/TokensTable.tsx
+++ b/src/wallet_frontend/src/TokensTable.tsx
@@ -7,13 +7,14 @@ import { createActor as createTokenActor } from '../../declarations/nns-ledger';
 import { createActor as createPstActor } from '../../declarations/pst';
 import { Account, _SERVICE as NNSLedger } from '../../declarations/nns-ledger/nns-ledger.did'; // TODO: hack
 import { Principal } from '@dfinity/principal';
-import { decodeIcrcAccount, IcrcLedgerCanister } from "@dfinity/ledger-icrc";
+import { decodeIcrcAccount, encodeIcrcAccount, IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { GlobalContext } from './state';
 import { ErrorContext } from '../../lib/ErrorContext';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import { Token, TransferError } from '../../declarations/wallet_backend/wallet_backend.did';
 import { Actor } from '@dfinity/agent';
+import { principalToSubaccount } from './accountUtils';
 
 interface UIToken {
     symbol: string;
@@ -171,11 +172,12 @@ const TokensTable = forwardRef<TokensTableRef, TokensTableProps>((props, ref) =>
     const [userWallet, setUserWallet] = useState<Account | undefined>();
     const [userWalletText, setUserWalletText] = useState<string | undefined>();
     useEffect(() => {
-        if (glob.walletBackend !== undefined && principal !== undefined) {
-            glob.walletBackend.getUserWallet(principal).then(f => setUserWallet(f));
-            glob.walletBackend.getUserWalletText(principal).then(f => setUserWalletText(f));
+        if (glob.walletBackendPrincipal !== undefined && principal !== undefined) {
+            const account = { owner: glob.walletBackendPrincipal, subaccount: principalToSubaccount(principal) };
+            setUserWallet(account as any);
+            setUserWalletText(encodeIcrcAccount(account));
         }
-    }, [glob.walletBackend, principal]);
+    }, [glob.walletBackendPrincipal, principal]);
     useEffect(() => {
         if (tokens === undefined || userWallet === undefined) {
             return;

--- a/src/wallet_frontend/src/accountUtils.ts
+++ b/src/wallet_frontend/src/accountUtils.ts
@@ -1,0 +1,20 @@
+import { Principal } from '@dfinity/principal';
+import { encodeIcrcAccount } from '@dfinity/ledger-icrc';
+
+export function principalToSubaccount(principal: Principal): Uint8Array {
+  const bytes = principal.toUint8Array();
+  const sub = new Uint8Array(32);
+  // copy the principal bytes directly, padding the rest with zeros
+  for (let i = 0; i < 32; i++) {
+    sub[i] = i < bytes.length ? bytes[i] : 0;
+  }
+  return sub;
+}
+
+export function userAccount(wallet: Principal, user: Principal) {
+  return { owner: wallet, subaccount: principalToSubaccount(user) };
+}
+
+export function userAccountText(wallet: Principal, user: Principal): string {
+  return encodeIcrcAccount(userAccount(wallet, user));
+}


### PR DESCRIPTION
## Summary
- rollback wallet canister's address helpers
- compute the user's wallet account on the frontend
- display the principal-based subaccount in TokensTable and use it for transfers
- explicitly zero the unused bytes in `principalToSubaccount`
- **fix principal byte copying**

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_685814de0440832192a584ad31c1015b