### PR TITLE
Fix ICPACK balance check

### DIFF
--- a/src/wallet_frontend/src/accountUtils.ts
+++ b/src/wallet_frontend/src/accountUtils.ts
@@ -3,10 +3,13 @@ import { encodeIcrcAccount } from '@dfinity/ledger-icrc';
 
 export function principalToSubaccount(principal: Principal): Uint8Array {
   const bytes = principal.toUint8Array();
-  const sub = new Uint8Array(32);
-  // copy the principal bytes directly, padding the rest with zeros
-  for (let i = 0; i < 32; i++) {
-    sub[i] = i < bytes.length ? bytes[i] : 0;
+  const sub = new Uint8Array(bytes.length + 1);
+  sub[0] = bytes.length;
+  sub.set(bytes, 1);
+  if (sub.length < 32) {
+    const padded = new Uint8Array(32);
+    padded.set(sub);
+    return padded;
   }
   return sub;
 }


### PR DESCRIPTION
## Summary
- revert the incorrect automatic finishBuyWithICP invocation
- correct principal-to-subaccount conversion so balance lookup matches backend
- pad principal subaccounts to 32 bytes so account addresses are correct

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6858570048408321a663c6ae98c509b8