### PR TITLE
Fix browser process.version undefined

### DIFF
--- a/src/package_manager_frontend/src/main.tsx
+++ b/src/package_manager_frontend/src/main.tsx
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.scss';
 
+// readable-stream expects `process.version` to exist, but browser polyfills may
+// omit it. Avoid runtime errors by providing a default value if missing.
+if (typeof process !== 'undefined' && typeof (process as any).version !== 'string') {
+  (process as any).version = '';
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- provide a default `process.version` when running frontend code

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_685866d782648321bc07c95a1dc83b02