### PR TITLE
Fix PST buy flow

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -235,11 +235,8 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_PST!),
         principal,
       );
-      const walletInfo = await glob.walletBackend.getUserWallet(principal);
-      const from_subaccount =
-        walletInfo.subaccount.length === 0
-          ? ([] as [])
-          : ([userAccount(glob.walletBackendPrincipal, principal).subaccount] as [Uint8Array]);
+      const account = userAccount(glob.walletBackendPrincipal, principal);
+      const from_subaccount = [account.subaccount] as [Uint8Array];
       await glob.walletBackend.do_secure_icrc1_transfer(
         Principal.fromText(process.env.CANISTER_ID_NNS_LEDGER!),
         {


### PR DESCRIPTION
## Summary
- revert incorrect wallet patch
- use `userAccount` to compute user wallet locally

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_685a3415df0c832195784258e307a838