### PR TITLE
Fix dividends lock cleanup on errors

### DIFF
--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -294,6 +294,12 @@ persistent actor class BootstrapperData(initialOwner: Principal) = this {
             lockDividendsAccount[i] := principalMap.delete(lockDividendsAccount[i], user);
             return amount;
         } catch (err) {
+            let cur = dividendsLock(i, user);
+            lockDividendsAccount[i] := principalMap.put(
+                lockDividendsAccount[i],
+                user,
+                {cur with transferring = false; createdAtTime = 0 : Nat64},
+            );
             Debug.trap("withdraw dividends failed: " # Error.message(err));
             0;
         };


### PR DESCRIPTION
## Summary
- reset lock flags when `putDividendsOnTmpAccount` fails

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_685cfafe943c8321b787db953b0349f6