### PR TITLE
Update dividend fee check and add equality test

### DIFF
--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -265,7 +265,7 @@ persistent actor class BootstrapperData(initialOwner: Principal) = this {
             var current = dividendsLock(i, user);
             let amount = current.owedAmount;
 
-            if (amount < Common.icp_transfer_fee) {
+            if (amount <= Common.icp_transfer_fee) {
                 lockDividendsAccount[i] := principalMap.delete(lockDividendsAccount[i], user);
                 return 0;
             };


### PR DESCRIPTION
## Summary
- allow owed amount equal to `Common.icp_transfer_fee` to skip transfer
- adjust retry dividend test expectations
- add unit test covering the fee equality case

## Testing
- `npx mocha test/dividends_retry.test.ts --require tsx`
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_685cfbc368808321a44d4d91b035e975