### PR TITLE
Fix Invest tab dividends API usage

### DIFF
--- a/src/wallet_frontend/src/Invest.tsx
+++ b/src/wallet_frontend/src/Invest.tsx
@@ -183,8 +183,8 @@ export default function Invest() {
         Principal.fromText(process.env.CANISTER_ID_BOOTSTRAPPER_DATA!),
         { agent },
       );
-      const owed = await dataActor.dividendsOwing({ icp: null });
-      const owedC = await dataActor.dividendsOwing({ cycles: null });
+      const owed = await dataActor.dividendsOwing({ icp: null }, principal!);
+      const owedC = await dataActor.dividendsOwing({ cycles: null }, principal!);
       // console.log("QQ", owed.toString(), owedC.toString());
       setOwedDividends(Number(owed.toString()) / Math.pow(10, DECIMALS));
       setOwedCycles(Number(owedC.toString()));


### PR DESCRIPTION
## Summary
- update Invest tab to pass `principal` when querying dividends

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_685d07b87544832183fc6edec73a0ab2