### PR TITLE
Refactor bootstrap auth into module

### DIFF
--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -4,10 +4,11 @@ import Debug "mo:base/Debug";
 import RBTree "mo:base/RBTree";
 import Time "mo:base/Time";
 import Int "mo:base/Int";
+import UserAuth "../lib/UserAuth";
 import Account "../lib/Account";
 
 persistent actor class BootstrapperData(initialOwner: Principal) = this {
-    public type PubKey = Blob;
+    public type PubKey = UserAuth.PubKey;
     public type FrontendTweaker = {
         frontend: Principal;
         user: Principal;

--- a/src/lib/UserAuth.mo
+++ b/src/lib/UserAuth.mo
@@ -1,0 +1,29 @@
+import Principal "mo:base/Principal";
+import Blob "mo:base/Blob";
+import Debug "mo:base/Debug";
+import ECDSA "mo:ecdsa";
+import PublicKey "mo:ecdsa/PublicKey";
+import Signature "mo:ecdsa/Signature";
+
+module {
+    public type PubKey = Blob;
+    public type PrivKey = Blob;
+
+    /// Verify that the signature was produced by the private key corresponding to `pubKey`.
+    /// Traps on malformed key or signature.
+    public func verifySignature(pubKey: PubKey, user: Principal, signature: Blob): Bool {
+        let publicKey = switch (PublicKey.fromBytes(Blob.toArray(pubKey).vals(), #spki)) {
+            case (#ok k) k;
+            case (#err e) {
+                Debug.trap("pubkey error: " # e);
+            };
+        };
+        let sig = switch (Signature.fromBytes(Blob.toArray(signature).vals(), ECDSA.Curve(#prime256v1), #raw)) {
+            case (#ok s) s;
+            case (#err e) {
+                Debug.trap("signature error: " # e);
+            };
+        };
+        publicKey.verify(Blob.toArray(Principal.toBlob(user)).vals(), sig);
+    };
+}

--- a/src/lib/signatures.ts
+++ b/src/lib/signatures.ts
@@ -1,0 +1,45 @@
+import { Principal } from '@dfinity/principal';
+
+export type PubKey = Uint8Array;
+export type PrivKey = CryptoKey;
+
+export async function getPublicKeyFromPrivateKey(privateKey: CryptoKey): Promise<CryptoKey> {
+  try {
+    const jwkPrivate = await crypto.subtle.exportKey('jwk', privateKey);
+    const jwkPublic = {
+      kty: jwkPrivate.kty,
+      crv: jwkPrivate.crv,
+      x: jwkPrivate.x,
+      y: jwkPrivate.y,
+      alg: jwkPrivate.alg,
+    } as JsonWebKey;
+    const publicKey = await crypto.subtle.importKey(
+      'jwk',
+      jwkPublic,
+      {
+        name: 'ECDSA',
+        namedCurve: jwkPrivate.crv,
+        hash: { name: 'SHA-256' },
+      },
+      true,
+      ['verify']
+    );
+    return publicKey;
+  } catch (error) {
+    console.error('Error deriving public key:', error);
+    throw error;
+  }
+}
+
+export async function signPrincipal(privateKey: CryptoKey, principal: Principal): Promise<Uint8Array> {
+  const signature = await crypto.subtle.sign(
+    {
+      name: 'ECDSA',
+      saltLength: 32,
+      hash: 'SHA-256',
+    },
+    privateKey,
+    principal.toUint8Array()
+  );
+  return new Uint8Array(signature);
+}


### PR DESCRIPTION
## Summary
- extract signature verification logic to `UserAuth.mo`
- add shared crypto helpers in `signatures.ts`
- use new module from bootstrapper backend and frontend
- move `UserAuth.mo` to lib and rename helper to `signatures.ts`

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68619c068db48321a8ffe0cbcd803709