### PR TITLE
Add post-install key workflow

### DIFF
--- a/src/common.mo
+++ b/src/common.mo
@@ -288,6 +288,8 @@ module {
         var packageRepoCanister: Principal;
         var modulesInstalledByDefault: HashMap.HashMap<Text, Principal>;
         additionalModules: HashMap.HashMap<Text, Buffer.Buffer<Principal>>;
+        /// Public key used to verify configuration requests for this installation.
+        var pubKey: ?Blob;
         var pinned: Bool;
     };
 
@@ -318,6 +320,7 @@ module {
         packageRepoCanister: Principal;
         modulesInstalledByDefault: [(Text, Principal)];
         additionalModules: [(Text, [Principal])];
+        pubKey: ?Blob;
         pinned: Bool;
     };
 
@@ -332,6 +335,7 @@ module {
                 func ((k, v): (Text, Buffer.Buffer<Principal>)): (Text, [Principal]) = (k, Buffer.toArray(v))
             )
         );
+        pubKey = info.pubKey;
         pinned = info.pinned;
     };
 
@@ -354,6 +358,7 @@ module {
             Text.equal,
             Text.hash,
         );
+        var pubKey = info.pubKey;
         var pinned = info.pinned;
     };
 


### PR DESCRIPTION
## Summary
- add public key field to installed package records
- create config key after installation and allow regeneration
- wallet backend checks signatures with caller-provided key
- wallet frontend finalizes installation using the private key
- revert example app to previous simple demo

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_686208e037e883218f1511b15a72d3ec