### PR TITLE
Add privkey to frontend link when owner not set

### DIFF
--- a/src/package_manager_frontend/src/InstalledPackage.tsx
+++ b/src/package_manager_frontend/src/InstalledPackage.tsx
@@ -5,11 +5,11 @@ import { FormEvent, useContext, useEffect, useState } from "react";
 import { SharedInstalledPackageInfo } from "../../declarations/package_manager/package_manager.did";
 import Button from "react-bootstrap/Button";
 import { SharedPackageInfo, SharedRealPackageInfo } from '../../declarations/repository/repository.did.js';
-import { Actor } from "@dfinity/agent";
 import { GlobalContext } from "./state";
 import Accordion from "react-bootstrap/Accordion";
 import Modal from "react-bootstrap/Modal";
 import { myUseNavigate } from "./MyNavigate";
+import { createActor as createWalletActor } from '../../declarations/wallet_backend';
 
 function uint8ArrayToUrlSafeBase64(uint8Array: Uint8Array) {
     const binaryString = String.fromCharCode(...uint8Array);
@@ -23,6 +23,11 @@ function uint8ArrayToUrlSafeBase64(uint8Array: Uint8Array) {
 export default function InstalledPackage(props: {}) {
     const navigate = myUseNavigate();
     const { installationId } = useParams();
+    const [searchParams] = useSearchParams();
+    const [installationPrivKey, setInstallationPrivKey] = useState<string | null>(
+        searchParams.get('installationPrivKey'),
+    );
+    const [walletIsAnonymous, setWalletIsAnonymous] = useState<boolean | undefined>();
     const {agent, ok, principal} = useAuth();
     const [pkg, setPkg] = useState<SharedInstalledPackageInfo | undefined>();
     const [frontend, setFrontend] = useState<string | undefined>();
@@ -47,13 +52,33 @@ export default function InstalledPackage(props: {}) {
             return;
         }
 
+        const modules = new Map(pkg.modulesInstalledByDefault);
+        const backendPrincipal = modules.get('backend');
+        if (backendPrincipal !== undefined) {
+            const wallet = createWalletActor(backendPrincipal, {agent});
+            wallet.isAnonymous().then(async anon => {
+                setWalletIsAnonymous(anon);
+                if (anon && installationPrivKey === null) {
+                    try {
+                        const pair = await window.crypto.subtle.generateKey({name: 'ECDSA', namedCurve: 'P-256'}, true, ['sign']);
+                        const pubKey = new Uint8Array(await window.crypto.subtle.exportKey('spki', pair.publicKey));
+                        await glob.packageManager!.setInstallationPubKey(BigInt(installationId!), pubKey);
+                        const privKeyEncoded = uint8ArrayToUrlSafeBase64(new Uint8Array(await window.crypto.subtle.exportKey('pkcs8', pair.privateKey)));
+                        setInstallationPrivKey(privKeyEncoded);
+                    } catch (_) {
+                        /* ignore errors */
+                    }
+                }
+            }).catch(() => {});
+        }
+
         const piReal: SharedRealPackageInfo = (pkg.package.specific as any).real;
-        if (piReal.frontendModule[0] !== undefined) { // There is a frontend module.
-            glob.packageManager!.getInstalledPackage(BigInt(0)).then(pkg0 => {
+        if (piReal.frontendModule[0] !== undefined) {
+            glob.packageManager!.getInstalledPackage(BigInt(0)).then(async pkg0 => {
                 const piReal0: SharedRealPackageInfo = (pkg0.package.specific as any).real;
                 const modules0 = new Map(pkg0.modulesInstalledByDefault);
                 const modules = new Map(pkg.modulesInstalledByDefault);
-                const frontendStr = modules.get(piReal.frontendModule[0]!)?.toString(); // `?` because `pkg` may be not yet set
+                const frontendStr = modules.get(piReal.frontendModule[0]!)?.toString();
                 if (frontendStr !== undefined) {
                     let url = getIsLocal() ? `http://${frontendStr}.localhost:8080` : `https://${frontendStr}.icp0.io`;
                     url += `?_pm_inst=${installationId}`;
@@ -63,11 +88,22 @@ export default function InstalledPackage(props: {}) {
                     for (let m of piReal0.modules) {
                         url += `&_pm_pkg0.${m[0]}=${modules0.get(m[0])!.toString()}`;
                     }
+                    if (walletIsAnonymous && installationPrivKey !== null) {
+                        url += `&installationPrivKey=${installationPrivKey}`;
+                    }
                     setFrontend(url);
                 }
             });
         }
-    }, [glob.packageManager, glob.backend, pkg]);
+    }, [
+        glob.packageManager,
+        pkg,
+        ok,
+        agent,
+        installationPrivKey,
+        walletIsAnonymous,
+        searchParams,
+    ]);
 
     function uninstall() {
         setUninstallConfirmationMessage("");
@@ -88,13 +124,6 @@ export default function InstalledPackage(props: {}) {
         }
     }
 
-    async function regenerateKey() {
-        const pair = await window.crypto.subtle.generateKey({name: 'ECDSA', namedCurve: 'P-256'}, true, ['sign']);
-        const pubKey = new Uint8Array(await window.crypto.subtle.exportKey('spki', pair.publicKey));
-        await glob.packageManager!.setInstallationPubKey(BigInt(installationId!), pubKey);
-        const privKeyEncoded = uint8ArrayToUrlSafeBase64(new Uint8Array(await window.crypto.subtle.exportKey('pkcs8', pair.privateKey)));
-        navigate(`/installed/show/${installationId}?installationPrivKey=${privKeyEncoded}`);
-    }
 
     return (
         <>
@@ -113,7 +142,6 @@ export default function InstalledPackage(props: {}) {
                         onClick={() => navigate(`/choose-upgrade/${pkg.packageRepoCanister}/${installationId}`)}
                     >Upgrade</Button>
                 </p>
-                <p><Button onClick={regenerateKey} disabled={!ok}>Generate configuration key</Button></p>
                 <p><strong>Frontend:</strong> {frontend === undefined ? <em>(none)</em> : <a href={frontend}>here</a>}</p>
                 <p><strong>Installation ID:</strong> {installationId}</p>
                 <p><strong>Package name:</strong> {pkg.package.base.name}</p>


### PR DESCRIPTION
## Summary
- automate wallet key generation when wallet has no owner
- include the key in the frontend link if wallet is anonymous
- improve installation key state handling

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*


------
https://chatgpt.com/codex/tasks/task_e_68652df7f33c8321b92b118ff1a650f4