### PR TITLE
Fix state for installation priv key

### DIFF
--- a/src/package_manager_frontend/src/InstalledPackage.tsx
+++ b/src/package_manager_frontend/src/InstalledPackage.tsx
@@ -24,8 +24,10 @@ export default function InstalledPackage(props: {}) {
     const navigate = myUseNavigate();
     const { installationId } = useParams();
     const [searchParams] = useSearchParams();
+    const [installationPrivKey, setInstallationPrivKey] = useState<string | null>(
+        searchParams.get('installationPrivKey'),
+    );
     const [walletIsAnonymous, setWalletIsAnonymous] = useState<boolean | undefined>();
-    const installationPrivKey = searchParams.get('installationPrivKey');
     const {agent, ok, principal} = useAuth();
     const [pkg, setPkg] = useState<SharedInstalledPackageInfo | undefined>();
     const [frontend, setFrontend] = useState<string | undefined>();


### PR DESCRIPTION
## Summary
- restore useState for installationPrivKey in InstalledPackage

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '../.dfx/local/canister_ids.json' or its corresponding type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68653b4a3f048321a72bd84d7fd329b6