### PR TITLE
Fix upgrade page navigation

### DIFF
--- a/src/package_manager_frontend/src/ChooseVersion.tsx
+++ b/src/package_manager_frontend/src/ChooseVersion.tsx
@@ -168,7 +168,7 @@ function ChooseVersion2(props: {
                     afterUpgradeCallback: [],
                 });
                 // await waitTillInitialized(agent!, glob.backend!, upgradeResult.minUpgradeId);
-                navigate(`/installed/show/${upgradeResult.minUpgradeId}`);
+                navigate(`/installed/show/${props.oldInstallation}`);
             }
         }
         catch (e) {


### PR DESCRIPTION
## Summary
- fix navigation after regular package upgrade to use installation id

## Testing
- `make deploy-test` *(fails: dfx not found)*
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68669f0496fc8321ae29fd7838a51599