### PR TITLE
Fix wallet setOwner signature

### DIFF
--- a/src/lib/signatures.ts
+++ b/src/lib/signatures.ts
@@ -31,15 +31,42 @@ export async function getPublicKeyFromPrivateKey(privateKey: CryptoKey): Promise
   }
 }
 
+function pad32(buf: Uint8Array): Uint8Array {
+  if (buf.length === 32) return buf;
+  if (buf.length > 32) return buf.slice(buf.length - 32);
+  const out = new Uint8Array(32);
+  out.set(buf, 32 - buf.length);
+  return out;
+}
+
+function derToRawSignature(der: Uint8Array): Uint8Array {
+  if (der[0] !== 0x30) throw new Error('Invalid DER');
+  let offset = 2; // skip 0x30 and length
+  if (der[offset] !== 0x02) throw new Error('Invalid DER');
+  offset += 1;
+  const rLen = der[offset++];
+  const r = der.slice(offset, offset + rLen);
+  offset += rLen;
+  if (der[offset] !== 0x02) throw new Error('Invalid DER');
+  offset += 1;
+  const sLen = der[offset++];
+  const s = der.slice(offset, offset + sLen);
+  const out = new Uint8Array(64);
+  out.set(pad32(r), 0);
+  out.set(pad32(s), 32);
+  return out;
+}
+
 export async function signPrincipal(privateKey: CryptoKey, principal: Principal): Promise<Uint8Array> {
-  const signature = await crypto.subtle.sign(
-    {
-      name: 'ECDSA',
-      saltLength: 32,
-      hash: 'SHA-256',
-    },
-    privateKey,
-    principal.toUint8Array()
+  const derSig = new Uint8Array(
+    await crypto.subtle.sign(
+      {
+        name: 'ECDSA',
+        hash: 'SHA-256',
+      },
+      privateKey,
+      principal.toUint8Array(),
+    ),
   );
-  return new Uint8Array(signature);
+  return derToRawSignature(derSig);
 }


### PR DESCRIPTION
## Summary
- convert browser ECDSA signature from DER to raw format so wallet can verify it

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6868acedfed48321936d3e62636808c6