### PR TITLE
Simplify wallet address handling

### DIFF
--- a/src/wallet_backend/wallet.mo
+++ b/src/wallet_backend/wallet.mo
@@ -178,31 +178,6 @@ persistent actor class Wallet({
         Principal.isAnonymous(owner);
     };
 
-    // TODO@P3: duplicate code
-    public query func getUserWallet(user: Principal): async {owner: Principal; subaccount: ?Blob} {
-        // onlyOwner(caller, "getUserWallet");
-
-        let canister = Principal.fromActor(this);
-        {owner = canister; subaccount =
-            if (Principal.isAnonymous(owner)) {
-                ?(AccountID.principalToSubaccount(user));
-            } else {
-                null;
-            }
-        };
-    };
-
-    public query func getUserWalletText(user: Principal): async Text {
-        // onlyOwner(caller, "getUserWallet");
-
-        let canister = Principal.fromActor(this);
-        if (Principal.isAnonymous(owner)) {
-            let subaccount = ?(AccountID.principalToSubaccount(user));
-            Account.toText({owner = canister; subaccount});
-        } else {
-            Principal.toText(canister);
-        }
-    };
 
 
     // query func isPersonalWallet(): async Bool {

--- a/src/wallet_frontend/src/TokensTable.tsx
+++ b/src/wallet_frontend/src/TokensTable.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../../lib/use-auth-client';
 import { createActor as createTokenActor } from '../../declarations/nns-ledger'; // TODO: hack
 import { createActor as createSwapFactory } from '../../declarations/swap-factory';
 import { createActor as createSwapPool } from '../../declarations/swap-pool';
-import { Account, _SERVICE as NNSLedger } from '../../declarations/nns-ledger/nns-ledger.did'; // TODO: hack
+import { _SERVICE as NNSLedger } from '../../declarations/nns-ledger/nns-ledger.did'; // TODO: hack
 import { Principal } from '@dfinity/principal';
 import { decodeIcrcAccount, IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { GlobalContext } from './state';
@@ -16,7 +16,6 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import Accordion from 'react-bootstrap/Accordion';
 import { Token } from '../../declarations/wallet_backend/wallet_backend.did';
 import { HttpAgent } from '@dfinity/agent';
-import { userAccount, userAccountText } from './accountUtils';
 
 interface UIToken {
     symbol: string;
@@ -135,17 +134,12 @@ const TokensTable = forwardRef<TokensTableRef, TokensTableProps>((props, ref) =>
     );
 
     const [balances, setBalances] = useState(new Map<Principal, number>());
-    const [userWallet, setUserWallet] = useState<Account | undefined>();
-    const [userWalletText, setUserWalletText] = useState<string | undefined>();
     const dfxCommand = principal === undefined
         ? ''
         : `dfx ledger --network ${process.env.DFX_NETWORK} transfer --to-principal ${principal.toText()} --memo 0 --amount`;
+    const userWalletText = principal?.toText();
     useEffect(() => {
-        setUserWallet({ owner: principal!, subaccount: [] });
-        setUserWalletText(principal!.toText()); // TODO@P1: Remove this code.
-    }, [principal]);
-    useEffect(() => {
-        if (tokens === undefined || userWallet === undefined) {
+        if (tokens === undefined || principal === undefined) {
             return;
         }
         for (const token of tokens) {
@@ -156,7 +150,7 @@ const TokensTable = forwardRef<TokensTableRef, TokensTableProps>((props, ref) =>
                     setBalances(new Map(balances)); // create new value.
                 });
         }
-    }, [tokens, defaultAgent, userWallet]);
+    }, [tokens, defaultAgent, principal]);
 
     async function initSendModal(token: any) { // TODO@P3: `any`
         setSelectedToken(token);

--- a/src/wallet_frontend/src/accountUtils.ts
+++ b/src/wallet_frontend/src/accountUtils.ts
@@ -1,7 +1,4 @@
 import { Principal } from '@dfinity/principal';
-import { encodeIcrcAccount } from '@dfinity/ledger-icrc';
-import { createActor as createWalletActor } from '../../declarations/wallet_backend'; // TODO: hack
-import { Wallet } from '../../declarations/wallet_backend/wallet_backend.did';
 
 // TODO@P3: duplicate code
 async function sha256(v: Uint8Array): Promise<Uint8Array> {
@@ -32,15 +29,4 @@ export function principalToSubaccount(principal: Principal): Uint8Array {
   return sub;
 }
 
-export async function userAccount(wallet: Principal, user: Principal, agent?: any) {
-  // return { owner: wallet, subaccount: principalToSubaccount(user) }; // `subaccount` should be `undefined`, if the wallet is personal.
-  const walletActor: Wallet = createWalletActor(wallet, agent ? { agent } : {});
-  return await walletActor.getUserWallet(user);
-}
-
-export async function userAccountText(wallet: Principal, user: Principal, agent?: any): Promise<string> {
-  // return encodeIcrcAccount(await userAccount(wallet, user));
-  const walletActor: Wallet = createWalletActor(wallet, agent ? { agent } : {});
-  return await walletActor.getUserWalletText(user);
-}
 


### PR DESCRIPTION
## Summary
- drop unused wallet address helpers
- compute wallet address directly from user principal
- simplify token table logic

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_686bba350a408321b8fba7919cb2e36f