### PR TITLE
Use backend wrapper for asset copying

### DIFF
--- a/src/package_manager_backend/package_manager.mo
+++ b/src/package_manager_backend/package_manager.mo
@@ -25,6 +25,7 @@ import LIB "mo:icpack-lib";
 import env "mo:env";
 // import Account "mo:icrc1/ICRC1/Account";
 import Battery "battery";
+import Install "../install";
 
 shared({caller = initialCaller}) actor class PackageManager({
     packageManager: Principal; // may be the bootstrapper instead.
@@ -1506,6 +1507,26 @@ shared({caller = initialCaller}) actor class PackageManager({
 
     public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
         await* LIB.withdrawCycles(/*CyclesLedger,*/ amount, payee, caller);
+    };
+
+    /// Copy assets from one canister to another if the module contains assets
+    /// wrapper around Install.copyAssetsIfAny from install.mo
+    public shared({caller}) func copyAssetsIfAny({
+        wasmModule: Common.SharedModule;
+        canister_id: Principal;
+        simpleIndirect: Principal;
+        mainIndirect: Principal;
+        user: Principal;
+    }): async () {
+        onlyOwner(caller, "copyAssetsIfAny");
+
+        await* Install.copyAssetsIfAny({
+            wasmModule = Common.unshareModule(wasmModule);
+            canister_id;
+            simpleIndirect;
+            mainIndirect;
+            user;
+        });
     };
 
     /// New API for step-by-step upgrades

--- a/src/package_manager_frontend/src/lib/modularUpgrade.ts
+++ b/src/package_manager_frontend/src/lib/modularUpgrade.ts
@@ -84,35 +84,6 @@ async function copyAllAssets(from: ActorSubclass<AssetService>, to: ActorSubclas
     await to.commit_batch({ batch_id, operations });
 }
 
-async function copyAssetsIfAny(opts: {
-    moduleInfo: SharedModule;
-    canisterId: Principal;
-    agent: Agent;
-    simpleIndirect: Principal;
-    mainIndirect: Principal;
-    user: Principal;
-}): Promise<void> {
-    const code = opts.moduleInfo.code as any;
-    if (code.Assets === undefined) return;
-    const fromId: Principal = code.Assets.assets;
-    const from = Actor.createActor<AssetService>(assetIdlFactory, { agent: opts.agent, canisterId: fromId });
-    const to = Actor.createActor<AssetService>(assetIdlFactory, { agent: opts.agent, canisterId: opts.canisterId });
-
-    await copyAllAssets(from, to);
-
-    const oldController = (await to.list_authorized())[0];
-    const perms: Permission[] = [{ Commit: null }, { Prepare: null }, { ManagePermissions: null }];
-    for (const permission of perms) {
-        for (const p of [opts.simpleIndirect, opts.mainIndirect, opts.user]) {
-            await to.grant_permission({ to_principal: p, permission });
-        }
-        if (oldController.toText() !== opts.simpleIndirect.toText() &&
-            oldController.toText() !== opts.mainIndirect.toText() &&
-            oldController.toText() !== opts.user.toText()) {
-            await to.revoke_permission({ of_principal: oldController, permission });
-        }
-    }
-}
 
 interface ModularUpgradeParams {
     package_manager: PackageManager;
@@ -262,10 +233,9 @@ export async function performModularUpgrade({
                         throw e;
                     }
                 }
-                await copyAssetsIfAny({
-                    moduleInfo,
-                    canisterId: moduleCanisterId,
-                    agent,
+                await package_manager.copyAssetsIfAny({
+                    wasmModule: moduleInfo,
+                    canister_id: moduleCanisterId,
                     simpleIndirect,
                     mainIndirect,
                     user: principal,
@@ -287,10 +257,9 @@ export async function performModularUpgrade({
                     wasmModule: wasmModuleBytes,
                     arg: new Uint8Array(arg),
                 });
-                await copyAssetsIfAny({
-                    moduleInfo,
-                    canisterId: newCanisterId,
-                    agent,
+                await package_manager.copyAssetsIfAny({
+                    wasmModule: moduleInfo,
+                    canister_id: newCanisterId,
                     simpleIndirect,
                     mainIndirect,
                     user: principal,
@@ -310,4 +279,4 @@ export async function performModularUpgrade({
     await package_manager.completeModularUpgrade(upgradeResult.upgradeId, Array.from(modulesMap.entries()));
 
     navigate(`/installed/show/${props.oldInstallation.toString()}`);
-} 
+}


### PR DESCRIPTION
## Summary
- expose `copyAssetsIfAny` through `package_manager` canister
- delegate asset copying in modular upgrade to the new backend method

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*


------
https://chatgpt.com/codex/tasks/task_e_686c8d0e8d60832199052d73fad4d4e5