### PR TITLE
Add developer account field to packages

### DIFF
--- a/scripts/prepare-test.ts
+++ b/scripts/prepare-test.ts
@@ -188,6 +188,7 @@ async function main() {
             shortDescription: "Example package",
             longDescription: "Used as an example",
             guid: Uint8Array.from([4, 222, 95, 192, 252, 162, 223, 235, 230, 55, 16, 42, 26, 177, 208, 208]),
+            developer: null,
         },
         specific: {real: paidExampleReal},
     };

--- a/src/common.mo
+++ b/src/common.mo
@@ -12,6 +12,7 @@ import Blob "mo:base/Blob";
 import Nat8 "mo:base/Nat8";
 import Sha256 "mo:sha2/Sha256";
 import Itertools "mo:itertools/Iter";
+import Account "lib/Account";
 
 module {
     public func intHash(value: Int): Hash.Hash {
@@ -43,6 +44,7 @@ module {
         price: Nat;
         shortDescription: Text;
         longDescription: Text;
+        developer: ?Account.Account;
     };
 
     // Probably, not very efficient.

--- a/src/package_manager_backend/package_manager.mo
+++ b/src/package_manager_backend/package_manager.mo
@@ -414,7 +414,7 @@ shared({caller = initialCaller}) actor class PackageManager({
         label l for (p in packages.vals()) {
             let info = await p.repo.getPackage(p.packageName, p.version);
             if (info.base.price != 0) {
-                let ?developer = p.developer else {
+                let ?developer = info.base.developer else {
                     // Dishonest to the developer? What else we can do?
                     await IC.ic.deposit(
                         battery,


### PR DESCRIPTION
## Summary
- add `developer` account to package metadata
- update payment handling to read the developer account from package info
- include developer info in the paid example test package

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68701ad81b0c83218f198537831bad6e