### PR TITLE
Fix WebCrypto signing options

### DIFF
--- a/icpack-js/index.ts
+++ b/icpack-js/index.ts
@@ -46,11 +46,10 @@ export async function signPrincipal(privateKey: CryptoKey, principal: Principal)
   const signature = await crypto.subtle.sign(
     {
       name: 'ECDSA',
-      saltLength: 32,
-      hash: 'SHA-256',
+      hash: { name: 'SHA-256' },
     },
     privateKey,
-    principal.toUint8Array()
+    principal.toUint8Array(),
   );
   return new Uint8Array(signature);
 }


### PR DESCRIPTION
## Summary
- update ECDSA sign options to use correct WebCrypto parameters

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6876812d8adc832197bdd015453ee708