### PR TITLE
Fix argument bug in install.mo

### DIFF
--- a/src/install.mo
+++ b/src/install.mo
@@ -178,7 +178,7 @@ module {
             arg;
             user;
             afterInstallCallback;
-            canister_id: Principal;
+            canister_id;
         });
     };
 


### PR DESCRIPTION
## Summary
- correct argument passing when installing module

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877ae8b5f64832199192d884f6b7021