### PR TITLE
Fix loop return when wait timeout reached

### DIFF
--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -125,6 +125,7 @@ export async function waitTillInitialized(agent: Agent, package_manager: Princip
             }
             if (i == 30) {
                 reject("Cannot initialize canisters, possibly not enough cycles on battery, fund your account");
+                return;
             }
             await new Promise<void>((resolve, _reject) => {
                 setTimeout(() => resolve(), 1000);


### PR DESCRIPTION
## Summary
- ensure `waitTillInitialized` stops polling after reject

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877b17ee2ac83218efd7fbf5bf19f1a