### PR TITLE
Fix commandOutput to handle errors

### DIFF
--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -1,5 +1,18 @@
 import { exec } from "child_process";
 
 export function commandOutput(command: string): Promise<string> {
-    return new Promise((resolve) => exec(command, function(error, stdout, stderr){ resolve(stdout); }));
+    return new Promise((resolve, reject) =>
+        exec(command, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            if (stderr) {
+                // Preserve the previous behaviour of returning stdout even if
+                // there are warnings, but surface them to the caller.
+                console.warn(stderr);
+            }
+            resolve(stdout);
+        })
+    );
 }


### PR DESCRIPTION
## Summary
- improve `commandOutput` in `scripts.ts` to reject on errors

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877b518c62c8321b25db68a22ab033c