### PR TITLE
Fix CMC.notify_top_up error logging

### DIFF
--- a/src/package_manager_backend/battery.mo
+++ b/src/package_manager_backend/battery.mo
@@ -366,7 +366,7 @@ shared({caller = initialOwner}) actor class Battery({
             canister_id = Principal.fromActor(this);
         });
         let #Ok cyclesAmount = res3 else {
-            Debug.trap("notify_top_up failed: " # debug_show(res2));
+            Debug.trap("notify_top_up failed: " # debug_show(res3));
         };
 
         {balance = cyclesAmount};


### PR DESCRIPTION
## Summary
- fix typo in battery canister when logging notify_top_up failure

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877bdbf91e08321b8fd2057edf2fd49