### PR TITLE
Fix TODO in addToken logic

### DIFF
--- a/src/wallet_frontend/src/TokensTable.tsx
+++ b/src/wallet_frontend/src/TokensTable.tsx
@@ -75,12 +75,13 @@ const TokensTable = forwardRef<TokensTableRef, TokensTableProps>((props, ref) =>
     const handleAddToken = async () => {
         if (!agent || !principal || !glob.walletBackend) return;
 
-        // TODO@P3: also `archiveCanisterId`:
         await glob.walletBackend.addToken({
             symbol: newToken.symbol,
             name: newToken.name,
             canisterId: newToken.canisterId!,
-            archiveCanisterId: [],
+            archiveCanisterId: newToken.archiveCanisterId === undefined
+                ? []
+                : [newToken.archiveCanisterId],
         });
         
         setShowAddModal(false);


### PR DESCRIPTION
## Summary
- handle optional `archiveCanisterId` when adding a new token

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877c5e9bdcc8321ba306fa83e3ff789