### PR TITLE
Fix ledger reference

### DIFF
--- a/examples/example_backend/main.mo
+++ b/examples/example_backend/main.mo
@@ -1,4 +1,5 @@
 import LIB "mo:icpack-lib";
+import CyclesLedger "canister:cycles_ledger";
 
 actor {
   public query func greet(name : Text) : async Text {
@@ -6,6 +7,6 @@ actor {
   };
 
   public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-    await* LIB.withdrawCycles(amount, payee, caller);
+    await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
   };
 };

--- a/examples/upgrade_example_backend/0.0.1/main1.mo
+++ b/examples/upgrade_example_backend/0.0.1/main1.mo
@@ -1,10 +1,11 @@
 import LIB "mo:icpack-lib";
+import CyclesLedger "canister:cycles_ledger";
 import Principal "mo:base/Principal";
 
 actor {
   public shared func f() {};
 
   public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-    await* LIB.withdrawCycles(amount, payee, caller);
+    await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
   };
 }

--- a/examples/upgrade_example_backend/0.0.1/main2.mo
+++ b/examples/upgrade_example_backend/0.0.1/main2.mo
@@ -1,4 +1,5 @@
 import LIB "mo:icpack-lib";
+import CyclesLedger "canister:cycles_ledger";
 import Principal "mo:base/Principal";
 
 actor {
@@ -6,6 +7,6 @@ actor {
 
   // TODO@P3: use other withdraw function.
   public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-    await* LIB.withdrawCycles(amount, payee, caller);
+    await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
   };
 }

--- a/examples/upgrade_example_backend/0.0.2/main2.mo
+++ b/examples/upgrade_example_backend/0.0.2/main2.mo
@@ -1,9 +1,10 @@
 import LIB "mo:icpack-lib";
+import CyclesLedger "canister:cycles_ledger";
 
 actor {
   public shared func f() {};
 
   public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-    await* LIB.withdrawCycles(amount, payee, caller);
+    await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
   };
 }

--- a/examples/upgrade_example_backend/0.0.2/main3.mo
+++ b/examples/upgrade_example_backend/0.0.2/main3.mo
@@ -1,9 +1,10 @@
 import LIB "mo:icpack-lib";
+import CyclesLedger "canister:cycles_ledger";
 
 actor {
   public shared func f() {};
 
   public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-    await* LIB.withdrawCycles(amount, payee, caller);
+    await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
   };
 }

--- a/icpack-lib/src/lib.mo
+++ b/icpack-lib/src/lib.mo
@@ -1,7 +1,6 @@
 import Principal "mo:base/Principal";
 import Debug "mo:base/Debug";
 import Nat64 "mo:base/Nat64";
-import CyclesLedger "canister:cycles_ledger"; // TODO@P3: canister import in a library is wrong
 
 module {
     type BlockIndex = Nat;
@@ -28,15 +27,20 @@ module {
         #GenericError : { message : Text; error_code : Nat };
     };
 
+    /// Interface for the cycles ledger actor used to perform withdrawals.
+    public type CyclesLedger = actor {
+        withdraw : shared TransferArgs -> async { #Err : TransferError; #Ok : BlockIndex };
+    };
+
     // public type MyICRC1 = actor {
     //     icrc1_transfer : shared TransferArgs -> async {#Err : TransferError; #Ok : BlockIndex};
     // };
 
-    public func withdrawCycles(/*_ledger: CyclesLedger,*/ amount: Nat, payee: Principal, caller: Principal) : async* () {
+    public func withdrawCycles(ledger: CyclesLedger, amount: Nat, payee: Principal, caller: Principal) : async* () {
         if (not Principal.isController(caller)) {
             Debug.trap("withdrawCycles: payee is not a controller");
         };
-        let res = await CyclesLedger.withdraw({
+        let res = await ledger.withdraw({
             amount;
             from_subaccount = null;
             to = payee;

--- a/src/package_manager_backend/battery.mo
+++ b/src/package_manager_backend/battery.mo
@@ -253,7 +253,7 @@ shared({caller = initialOwner}) actor class Battery({
     addWithdrawer(packageManager);
 
     public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-        await* LIB.withdrawCycles(/*CyclesLedger,*/ amount, payee, caller);
+        await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
     };
 
     public shared({caller}) func depositCycles(amount: Nat, payee: CyclesLedger.Account) : async () {

--- a/src/package_manager_backend/main_indirect.mo
+++ b/src/package_manager_backend/main_indirect.mo
@@ -553,6 +553,6 @@ shared({caller = initialCaller}) actor class MainIndirect({
 //    };
 
     public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-        await* LIB.withdrawCycles(/*CyclesLedger,*/ amount, payee, caller);
+        await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
     };
 }

--- a/src/package_manager_backend/package_manager.mo
+++ b/src/package_manager_backend/package_manager.mo
@@ -1554,7 +1554,7 @@ shared({caller = initialCaller}) actor class PackageManager({
     };
 
     public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
-        await* LIB.withdrawCycles(/*CyclesLedger,*/ amount, payee, caller);
+        await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
     };
 
     /// Copy assets from one canister to another if the module contains assets

--- a/src/package_manager_backend/simple_indirect.mo
+++ b/src/package_manager_backend/simple_indirect.mo
@@ -10,6 +10,7 @@ import Blob "mo:base/Blob";
 import IC "mo:ic";
 import Common "../common";
 import LIB "mo:icpack-lib";
+import CyclesLedger "canister:cycles_ledger";
 
 shared({caller = initialCaller}) actor class SimpleIndirect({
     packageManager: Principal; // may be the bootstrapper instead.
@@ -548,7 +549,7 @@ shared({caller = initialCaller}) actor class SimpleIndirect({
 
     public shared({caller}) func withdrawCycles(amount: Nat, payee: Principal) : async () {
         try {
-            await* LIB.withdrawCycles(/*CyclesLedger,*/ amount, payee, caller);
+            await* LIB.withdrawCycles(CyclesLedger, amount, payee, caller);
         }
         catch (e) {
             let msg = "withdrawCycles: " # Error.message(e);


### PR DESCRIPTION
## Summary
- refactor `withdrawCycles` to accept a `CyclesLedger` actor
- pass the ledger actor from callers in backends and examples

## Testing
- `npm test` *(fails: Cannot find module '../declarations/package_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877ccb551e8832190d5f34f2f53493f