### PR TITLE
Fix one todo or fixme

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,6 @@ Remaining things TODO
 - TODO@P3 Automatically retrieve the name of the added repo.
 
 - TODO@P3: `inspect`.
-- ✅ FIXED: Consolidated duplicate SHA-256 implementations in `src/wallet_frontend/src/accountUtils.ts` and `src/lib/install.ts` into shared utility `src/lib/crypto.ts`.
 
 - TODO@P3 Option to install additional software after bootstrapping.
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@ Remaining things TODO
 - TODO@P3 Automatically retrieve the name of the added repo.
 
 - TODO@P3: `inspect`.
+- ✅ FIXED: Consolidated duplicate SHA-256 implementations in `src/wallet_frontend/src/accountUtils.ts` and `src/lib/install.ts` into shared utility `src/lib/crypto.ts`.
 
 - TODO@P3 Option to install additional software after bootstrapping.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "src/package_manager_frontend",
         "src/repository_frontend",
         "src/wallet_frontend",
-        "examples/example_frontend"
+        "examples/example_frontend",
+        "icpack-js"
       ],
       "dependencies": {
         "@dfinity/agent": "^2.4.1",
@@ -98,6 +99,10 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "icpack-js": {
+      "name": "icpack",
+      "version": "1.0.0"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -3385,6 +3390,10 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/icpack": {
+      "resolved": "icpack-js",
+      "link": true
     },
     "node_modules/idb": {
       "version": "7.1.1",

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared crypto utilities for the icpack project
+ */
+
+/**
+ * Computes SHA-256 hash of the given data
+ * Works in both browser and Node.js environments
+ */
+export async function sha256(v: Uint8Array): Promise<Uint8Array> {
+  if (typeof window !== 'undefined') {
+    // In browsers prefer the WebCrypto API. Avoid importing the Node
+    // `crypto` polyfill which pulls in heavy dependencies and may rely on
+    // `process.version` being defined.
+    return new Uint8Array(await crypto.subtle.digest('SHA-256', v));
+  } else {
+    // Node.js environment
+    const { createHash } = await import('crypto');
+    const hash = createHash('sha256');
+    hash.update(v);
+    return new Uint8Array(hash.digest());
+  }
+}

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -18,10 +18,7 @@ async function getRandomValues(v: Uint8Array): Promise<Uint8Array> {
     }
 }
 
-// TODO@P3: duplicate code
-async function sha256(v: Uint8Array): Promise<Uint8Array> {
-    return new Uint8Array(await subtle.digest('SHA-256', v));
-}
+import { sha256 } from './crypto';
 
 export async function bootstrapFrontend(props: {agent: Agent}) {
     const repoIndex = createRepositoryIndexActor(process.env.CANISTER_ID_REPOSITORY!, {agent: props.agent}); // TODO@P3: `defaultAgent` here and in other places.

--- a/src/wallet_frontend/src/accountUtils.ts
+++ b/src/wallet_frontend/src/accountUtils.ts
@@ -1,20 +1,5 @@
 import { Principal } from '@dfinity/principal';
-
-// TODO@P3: duplicate code
-async function sha256(v: Uint8Array): Promise<Uint8Array> {
-  if (typeof window !== 'undefined') {
-    // In browsers prefer the WebCrypto API. Avoid importing the Node
-    // `crypto` polyfill which pulls in heavy dependencies and may rely on
-    // `process.version` being defined.
-    return new Uint8Array(await crypto.subtle.digest('SHA-256', v));
-  } else {
-    // Node.js environment
-    const { createHash } = await import('crypto');
-    const hash = createHash('sha256');
-    hash.update(v);
-    return new Uint8Array(hash.digest());
-  }
-}
+import { sha256 } from '../../lib/crypto';
 
 export function principalToSubaccount(principal: Principal): Uint8Array {
   const bytes = principal.toUint8Array();


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Consolidate duplicate SHA-256 implementations into a shared utility to improve maintainability and consistency.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses a `TODO@P3: duplicate code` comment by consolidating two separate SHA-256 implementations found in `src/wallet_frontend/src/accountUtils.ts` and `src/lib/install.ts`. The more robust implementation (supporting both browser and Node.js environments) was moved to a new shared utility file (`src/lib/crypto.ts`), and both original files were updated to import from this new central location.

---
<a href="https://cursor.com/background-agent?bcId=bc-49b4075d-a2da-4554-97d4-6463c16a844d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49b4075d-a2da-4554-97d4-6463c16a844d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>