### PR TITLE
Fix one todo or fixme

### DIFF
--- a/src/common.mo
+++ b/src/common.mo
@@ -452,4 +452,8 @@ module {
     public let icp_transfer_fee = 10_000;
 
     public let minimalFunding = 13_000_000_000_000;
+
+    // Wallet default settings
+    public let default_amount_add_checkbox = 10.0;
+    public let default_amount_add_input = 30.0;
 }

--- a/src/common.mo
+++ b/src/common.mo
@@ -454,6 +454,7 @@ module {
     public let minimalFunding = 13_000_000_000_000;
 
     // Wallet default settings
+    // These should match the values used in src/wallet_frontend/src/Settings.tsx
     public let default_amount_add_checkbox = 10.0;
     public let default_amount_add_input = 30.0;
 }

--- a/src/wallet_backend/wallet.mo
+++ b/src/wallet_backend/wallet.mo
@@ -48,8 +48,8 @@ persistent actor class Wallet({
 
     private func initialUserData(): UserData {
         {
-            var amountAddCheckbox = ?10.0;
-            var amountAddInput = ?30.0;
+            var amountAddCheckbox = ?Common.default_amount_add_checkbox;
+            var amountAddInput = ?Common.default_amount_add_input;
             var tokens = defaultTokens();
         }
     };

--- a/src/wallet_frontend/src/Settings.tsx
+++ b/src/wallet_frontend/src/Settings.tsx
@@ -4,11 +4,7 @@ import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import { useAuth } from '../../lib/use-auth-client';
 import { GlobalContext } from './state';
-
-// Helper function to extract first value from array with default fallback
-const getFirstValueOrDefault = <T,>(array: T[] | undefined, defaultValue: T): T => {
-    return array?.[0] ?? defaultValue;
-};
+import { DEFAULT_AMOUNT_ADD_CHECKBOX, DEFAULT_AMOUNT_ADD_INPUT } from './constants';
 
 export default function Settings() {
     const { agent, ok, principal } = useAuth();
@@ -21,8 +17,8 @@ export default function Settings() {
         if (!agent || !principal || !glob.walletBackend) return;
 
         const limits = await glob.walletBackend.getLimitAmounts();
-        setAmountAddCheckbox(getFirstValueOrDefault(limits.amountAddCheckbox, 10));
-        setAmountAddInput(getFirstValueOrDefault(limits.amountAddInput, 30));
+        setAmountAddCheckbox(limits.amountAddCheckbox[0] ?? DEFAULT_AMOUNT_ADD_CHECKBOX);
+        setAmountAddInput(limits.amountAddInput[0] ?? DEFAULT_AMOUNT_ADD_INPUT);
     };
 
     function doSetAmountAddCheckbox(e: HTMLInputElement) {

--- a/src/wallet_frontend/src/Settings.tsx
+++ b/src/wallet_frontend/src/Settings.tsx
@@ -5,6 +5,11 @@ import Button from 'react-bootstrap/Button';
 import { useAuth } from '../../lib/use-auth-client';
 import { GlobalContext } from './state';
 
+// Helper function to extract first value from array with default fallback
+const getFirstValueOrDefault = <T,>(array: T[] | undefined, defaultValue: T): T => {
+    return array?.[0] ?? defaultValue;
+};
+
 export default function Settings() {
     const { agent, ok, principal } = useAuth();
     const [amountAddCheckbox, setAmountAddCheckbox] = useState<number | undefined>();
@@ -16,8 +21,8 @@ export default function Settings() {
         if (!agent || !principal || !glob.walletBackend) return;
 
         const limits = await glob.walletBackend.getLimitAmounts();
-        setAmountAddCheckbox(limits.amountAddCheckbox[0] ?? 10); // FIXME@P3: duplicate code
-        setAmountAddInput(limits.amountAddInput[0] ?? 30);
+        setAmountAddCheckbox(getFirstValueOrDefault(limits.amountAddCheckbox, 10));
+        setAmountAddInput(getFirstValueOrDefault(limits.amountAddInput, 30));
     };
 
     function doSetAmountAddCheckbox(e: HTMLInputElement) {

--- a/src/wallet_frontend/src/constants.ts
+++ b/src/wallet_frontend/src/constants.ts
@@ -1,4 +1,5 @@
 // Default values for wallet settings
-// These should match the values defined in the backend (src/wallet_backend/wallet.mo)
+// These should match the values defined in src/common.mo
+// Backend uses: Common.default_amount_add_checkbox and Common.default_amount_add_input
 export const DEFAULT_AMOUNT_ADD_CHECKBOX = 10;
 export const DEFAULT_AMOUNT_ADD_INPUT = 30;

--- a/src/wallet_frontend/src/constants.ts
+++ b/src/wallet_frontend/src/constants.ts
@@ -1,0 +1,4 @@
+// Default values for wallet settings
+// These should match the values defined in the backend (src/wallet_backend/wallet.mo)
+export const DEFAULT_AMOUNT_ADD_CHECKBOX = 10;
+export const DEFAULT_AMOUNT_ADD_INPUT = 30;


### PR DESCRIPTION
Introduce shared frontend constants for default wallet settings to eliminate duplication with backend definitions.

This addresses a FIXME by centralizing the default values (10 and 30) for `amountAddCheckbox` and `amountAddInput`, which were previously hardcoded in `Settings.tsx` while also being defined in `src/wallet_backend/wallet.mo`.

---
<a href="https://cursor.com/background-agent?bcId=bc-285bb309-927f-41f2-aa27-5b6331ad8cf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-285bb309-927f-41f2-aa27-5b6331ad8cf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>