### PR TITLE
Fix duplicate withdrawCycles definition in battery.mo

### DIFF
--- a/src/package_manager_backend/battery.mo
+++ b/src/package_manager_backend/battery.mo
@@ -296,8 +296,8 @@ shared({caller = initialOwner}) actor class Battery({
         await IC.ic.deposit_cycles({canister_id = payee});
     };
 
-    public shared({caller}) func withdrawCycles() {
-        onlyOwner(caller, "withdrawCycles");
+    public shared({caller}) func withdrawAllCycles() {
+        onlyOwner(caller, "withdrawAllCycles");
 
         let balance = await CyclesLedger.icrc1_balance_of({
             owner = Principal.fromActor(this); subaccount = null;


### PR DESCRIPTION
Rename `withdrawCycles()` to `withdrawAllCycles()` in `battery.mo` to resolve a duplicate definition error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e124405f-f127-48ca-b4b5-4491c44bcc39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e124405f-f127-48ca-b4b5-4491c44bcc39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>