### PR TITLE
Fix one todo or fixme item

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -330,8 +330,7 @@
           "name": "candid:service"
         }
       ],
-      "type": "motoko",
-      "init_arg": "record { user = principal \"2vxsx-fae\" }"
+      "type": "motoko"
     },
     "wallet_frontend": {
       "args": "--enhanced-orthogonal-persistence",

--- a/src/wallet_backend/wallet.mo
+++ b/src/wallet_backend/wallet.mo
@@ -21,11 +21,9 @@ import UserAuth "mo:icpack-lib/UserAuth";
 
 persistent actor class Wallet({
     installationId: Nat;
-    // TODO@P2: Remove wrong value of user also from other packages and from initialization code.
-    // user: Principal; // Pass the anonymous principal `2vxsx-fae` to be controlled by nobody.
     packageManager: Principal;
 }) = this {
-    stable var owner = Principal.fromText("2vxsx-fae");
+    stable var owner = Principal.fromText("2vxsx-fae"); // Anonymous principal - will be replaced by actual user via setOwner method
 
     private func onlyOwner(caller: Principal, msg: Text) {
         if (not Principal.isAnonymous(owner) and caller != owner) {


### PR DESCRIPTION
Remove hardcoded anonymous principal from wallet initialization to rely on the `setOwner` method for secure user ownership.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0d0fb41-2f11-4e9c-8560-16b2fc977cae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0d0fb41-2f11-4e9c-8560-16b2fc977cae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>