### PR TITLE
Fix a code comment issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 Remaining things TODO
 
-- FIXME@P3 Clicking Reload button should not switch from Cycles to ICP tab in the payment popup.
+- ✅ FIXME@P3 Clicking Reload button should not switch from Cycles to ICP tab in the payment popup.
 
 - TODO@P2 Withdraw cycles when uninstalling a package.
 

--- a/src/bootstrapper_frontend/src/App.tsx
+++ b/src/bootstrapper_frontend/src/App.tsx
@@ -60,6 +60,7 @@ function AddressPopup(props: {
   const {agent} = useAuth();
   const address = props.cyclesPaymentAddress!;
   const [copied, setCopied] = useState(false);
+  const [activeTab, setActiveTab] = useState("icp");
   const copyToClipboard = async (event: React.MouseEvent) => {
     const str = (event.target as HTMLElement).innerText;
     navigator.clipboard.writeText(str).then(() => {
@@ -108,7 +109,7 @@ function AddressPopup(props: {
         {/* <p>ICP balance: {props.icpAmount !== undefined ? `${String(props.icpAmount/10**8)}` : "Loading..."}</p> */}
         <p><strong>Warning: 5% fee applied.</strong></p>
         <p>Fund it with 13T cycles, at least.</p>
-        <Tabs defaultActiveKey="icp">
+        <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k || "icp")}>
           <Tab eventKey="icp" title="ICP">
             <p>ICP to top-up:{" "}
               {props.icpAmount !== undefined ? `${String(props.icpAmount/10**8)}` : "Loading..."}

--- a/src/package_manager_frontend/src/App.tsx
+++ b/src/package_manager_frontend/src/App.tsx
@@ -268,6 +268,7 @@ function App2() {
   }) {
     const address = cyclesPaymentAddress!;
     const [copied, setCopied] = useState(false);
+    const [activeTab, setActiveTab] = useState("icp");
     const copyToClipboard = async (event: React.MouseEvent) => {
       const str = (event.target as HTMLElement).innerText;
       navigator.clipboard.writeText(str).then(() => {
@@ -289,7 +290,7 @@ function App2() {
         <div>
           {/* <p>ICP balance: {props.icpAmount !== undefined ? `${String(props.icpAmount/10**8)}` : "Loading..."}</p> */}
           <p><strong>Warning: 5% fee applied.</strong></p>
-          <Tabs defaultActiveKey="icp">
+          <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k || "icp")}>
             <Tab eventKey="icp" title="ICP">
               <p>ICP to top-up:{" "}
                 {props.icpAmount !== undefined ? `${String(props.icpAmount/10**8)}` : "Loading..."}


### PR DESCRIPTION
Make AddressPopup tabs persistent across re-renders to prevent unwanted tab switching on reload.

Previously, the `AddressPopup` component would reset to the default 'ICP' tab upon re-render (e.g., after clicking the reload button), disrupting the user experience. This fix introduces state management for the active tab, ensuring the selected tab is preserved.

---
<a href="https://cursor.com/background-agent?bcId=bc-56b4b72b-d706-4424-96f5-8cdb60f8e80a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56b4b72b-d706-4424-96f5-8cdb60f8e80a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>