### PR TITLE
Fix a code comment issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Remaining things TODO
 
 - TODO@P3 Fiat payments: https://github.com/Expeera/IC-PayPortal/tree/phase-3
 
-- FIXME@P3 After logout/login on `/choose-upgrade/*`, we have "Upgrade package" button disabled.
+- FIXME@P3 After logout/login on `/choose-upgrade/*`, we have "Upgrade package" button disabled. [FIXED: Added `agent` to useEffect dependency array and authentication check to upgrade button]
 
 - TODO@P3 (For saving gas) does it make sense to check module hash before upgrading it?
 

--- a/src/package_manager_frontend/src/ChooseVersion.tsx
+++ b/src/package_manager_frontend/src/ChooseVersion.tsx
@@ -93,7 +93,7 @@ function ChooseVersion2(props: {
                 }
             });
         }
-    }, [glob.packageManager, props.packageName, props.repo]); // TODO@P3: Check if `agent` is needed here (without it, it doesn't work properly).
+    }, [glob.packageManager, props.packageName, props.repo, agent]); // Fixed: Added `agent` to dependency array to ensure proper re-rendering after authentication changes
     const [chosenVersion, setChosenVersion] = useState<string | undefined>(undefined);
     const [installing, setInstalling] = useState(false);
     let errorContext = useContext(ErrorContext);
@@ -223,7 +223,7 @@ function ChooseVersion2(props: {
                 </p>
                 <p>
                     {props.oldInstallation !== undefined ?
-                        <Button onClick={upgrade} disabled={installing || chosenVersion === undefined}>Upgrade package</Button>
+                        <Button onClick={upgrade} disabled={!ok || installing || chosenVersion === undefined}>Upgrade package</Button>
                         : installedVersions.size == 0
                         ? <Button onClick={install} disabled={installing || chosenVersion === undefined}>Install new package</Button>
                         : installedVersions.has(chosenVersion ?? "")


### PR DESCRIPTION
Fix 'Upgrade package' button remaining disabled after logout/login by updating `useEffect` dependencies and adding an authentication check.

The "Upgrade package" button on `/choose-upgrade/*` pages remained disabled after logout/login because the `useEffect` hook fetching package data wasn't re-triggered when the authentication `agent` changed. Additionally, the button's `disabled` condition didn't explicitly check the authentication status (`ok`). This PR adds `agent` to the `useEffect` dependencies and includes `!ok` in the button's disabled condition, ensuring it correctly reflects the user's authentication state.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9841d4d-1bfb-4527-96b4-e2619f2c520c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9841d4d-1bfb-4527-96b4-e2619f2c520c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>