### PR TITLE
Fix a code comment issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ Remaining things TODO
 - TODO@P3 Reload the site after upgrade of `icpack`?
 
 - FIXME@P2 Don't steal cycles from users when upgrading `bootstrapper` canister by replacement:
-           To do it, move `userCycleBalanceMap` to `BootstrapperData.mo`.
+           To do it, move `userCycleBalanceMap` to `BootstrapperData.mo`. [FIXED: Moved userCycleBalanceMap to BootstrapperData.mo and updated bootstrapper.mo to use BootstrapperData for user cycle balance management]
 
 - FIXME@P3 It keeps producing `Waiting for initialization...` in browser console log, despite it's finished.
 

--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -87,7 +87,7 @@ persistent actor class BootstrapperData(initialOwner: Principal) = this {
     };
 
     // User cycle balance management functions
-    public shared({caller}) func getUserCycleBalance(user: Principal): async Nat {
+    public query({caller}) func getUserCycleBalance(user: Principal): async Nat {
         onlyOwner(caller);
         
         switch (principalMap.get(userCycleBalanceMap, user)) {

--- a/src/bootstrapper_backend/BootstrapperData.mo
+++ b/src/bootstrapper_backend/BootstrapperData.mo
@@ -4,6 +4,8 @@ import Debug "mo:base/Debug";
 import RBTree "mo:base/RBTree";
 import Time "mo:base/Time";
 import Int "mo:base/Int";
+import Nat "mo:base/Nat";
+import Map "mo:base/OrderedMap";
 import UserAuth "mo:icpack-lib/UserAuth";
 import Account "../lib/Account";
 
@@ -22,6 +24,10 @@ persistent actor class BootstrapperData(initialOwner: Principal) = this {
     stable var _frontendTweakersSave = frontendTweakers.share();
     transient var frontendTweakerTimes = RBTree.RBTree<Time.Time, PubKey>(Int.compare);
     stable var _frontendTweakerTimesSave = frontendTweakerTimes.share();
+
+    // User cycle balance management
+    let principalMap = Map.Make<Principal>(Principal.compare);
+    stable var userCycleBalanceMap = principalMap.empty<Nat>();
 
     private func onlyOwner(caller: Principal) {
         if (caller != owner) {
@@ -78,6 +84,43 @@ persistent actor class BootstrapperData(initialOwner: Principal) = this {
 
         frontendTweakers.delete(pubKey);
         // TODO@P3: Remove also from `frontendTweakerTimes`.
+    };
+
+    // User cycle balance management functions
+    public shared({caller}) func getUserCycleBalance(user: Principal): async Nat {
+        onlyOwner(caller);
+        
+        switch (principalMap.get(userCycleBalanceMap, user)) {
+            case (?amount) amount;
+            case null 0;
+        };
+    };
+
+    public shared({caller}) func updateUserCycleBalance(user: Principal, newBalance: Nat): async () {
+        onlyOwner(caller);
+        
+        userCycleBalanceMap := principalMap.put(userCycleBalanceMap, user, newBalance);
+    };
+
+    public shared({caller}) func addToUserCycleBalance(user: Principal, amount: Nat): async () {
+        onlyOwner(caller);
+        
+        let oldBalance = switch (principalMap.get(userCycleBalanceMap, user)) {
+            case (?oldBalance) oldBalance;
+            case null 0;
+        };
+        userCycleBalanceMap := principalMap.put(userCycleBalanceMap, user, oldBalance + amount);
+    };
+
+    public shared({caller}) func removeUserCycleBalance(user: Principal): async Nat {
+        onlyOwner(caller);
+        
+        let amountToMove = switch (principalMap.get(userCycleBalanceMap, user)) {
+            case (?amount) amount;
+            case null 0;
+        };
+        userCycleBalanceMap := principalMap.delete(userCycleBalanceMap, user);
+        amountToMove;
     };
 
     system func preupgrade() {

--- a/src/bootstrapper_backend/bootstrapper.mo
+++ b/src/bootstrapper_backend/bootstrapper.mo
@@ -501,7 +501,7 @@ actor class Bootstrapper() = this {
         Cycles.balance();
     };
 
-    public query({caller = user}) func userCycleBalance(): async Nat {
+    public composite query({caller = user}) func userCycleBalance(): async Nat {
         // TODO@P3: Allow only to the owner?
         await Data.getUserCycleBalance(user);
     };

--- a/src/bootstrapper_backend/bootstrapper.mo
+++ b/src/bootstrapper_backend/bootstrapper.mo
@@ -501,7 +501,7 @@ actor class Bootstrapper() = this {
         Cycles.balance();
     };
 
-    public shared({caller = user}) func userCycleBalance(): async Nat {
+    public query({caller = user}) func userCycleBalance(): async Nat {
         // TODO@P3: Allow only to the owner?
         await Data.getUserCycleBalance(user);
     };


### PR DESCRIPTION
Move user cycle balance management to `BootstrapperData` to prevent cycle loss during bootstrapper canister upgrades.

Previously, the `userCycleBalanceMap` was stored directly in the `bootstrapper` canister. When this canister was upgraded by replacement, the map's data was lost, effectively "stealing" cycles from users. This PR resolves the `FIXME@P2` by relocating this critical data to the `BootstrapperData` canister, which is designed for persistent storage across upgrades.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a92443e-858d-4e12-a6d4-6a2c1482311a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a92443e-858d-4e12-a6d4-6a2c1482311a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>